### PR TITLE
ci: PyPI公開のCI/リリース基盤を整備

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Trusted Publishing（OIDC）に必要。PyPI 側で API トークンは発行しない
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Run mypy
         run: python -m mypy
+
+  package-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Install built wheel
+        run: pip install dist/*.whl
+
+      - name: Import from outside the repo
+        # cwd の src/ を拾わないよう /tmp で実行し、wheel からのみ import できることを確認する
+        run: cd /tmp && python -c "import jpoke; print(jpoke.__version__)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+このプロジェクトの変更点はすべてこのファイルに記録する。
+
+フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に、
+バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に準拠する。
+
+## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ pip install jpoke
 
 `requires-python = ">=3.10"`。型アノテーションは Python 3.10+ の構文（`X | Y`, `list[X]`）を使用する。
 
+バージョニングは [Semantic Versioning](https://semver.org/lang/ja/) に準拠するが、0.x 系の間は
+minor バージョンの更新（例: 0.1.0 → 0.2.0）でも破壊的変更が入る場合がある。変更履歴は
+[CHANGELOG.md](https://github.com/tmwork1/jpoke/blob/main/CHANGELOG.md) を参照。
+
 ## クイックスタート
 
 もっとも低レベルな API（`Battle` / `Player` / `Pokemon`）だけを使った最小例:

--- a/docs/plan/pypi_release.md
+++ b/docs/plan/pypi_release.md
@@ -153,6 +153,10 @@ PyPI のプロジェクトページは `readme = "README.md"` をそのまま表
 
 ### 3-1. CI に wheel 検証ジョブを追加
 
+- 実施済み（`.github/workflows/test.yml` に `package-check` ジョブを追加。
+  `python -m build` → `twine check dist/*` → wheel インストール → `/tmp` からの
+  `import jpoke` の一連をローカルでも再現確認済み）
+
 今回の致命的不具合（1-1）を CI が素通しした根本原因は、`test.yml` が
 `pip install -e .`（editable）しか行わないこと。`.github/workflows/test.yml` に追加:
 
@@ -173,6 +177,14 @@ package-check:
 
 ### 3-2. publish ワークフローの新設
 
+- 実施済み（`.github/workflows/publish.yml` を新設。`v*` タグの push をトリガーに
+  build → publish の2ジョブ構成、publish ジョブに `environment: pypi` と
+  `permissions: id-token: write` を設定し `pypa/gh-action-pypi-publish@release/v1` で
+  Trusted Publishing する。YAML 構文はローカルで PyYAML により検証済み）
+- 未実施（ユーザー側作業）: PyPI 側での pending publisher
+  （リポジトリ `tmwork1/jpoke` / workflow `publish.yml` / environment `pypi`）の事前登録、
+  および GitHub 側の `pypi` environment 作成・保護ルール設定
+
 `.github/workflows/publish.yml` を追加。`v*` タグの push をトリガーに
 Trusted Publishing（OIDC、`pypa/gh-action-pypi-publish`）で公開する。
 PyPI 側で pending publisher（リポジトリ `tmwork1/jpoke` / workflow `publish.yml`）を
@@ -180,10 +192,12 @@ PyPI 側で pending publisher（リポジトリ `tmwork1/jpoke` / workflow `publ
 
 ### 3-3. バージョニングと初回リリース
 
-- semver を採用（0.x 系は minor bump で破壊的変更があり得る旨を README に一言）
-- `CHANGELOG.md` を新設（Keep a Changelog 形式）し、`[project.urls]` に `Changelog` を追加
-- 初回公開は `version = "0.1.0"` に上げ、`v0.1.0` タグを打つ
-- 公開前に TestPyPI で一度リハーサルする（publish.yml に TestPyPI ジョブを含めるか手動）
+- 実施済み: semver 採用方針を README に明記（0.x 系は minor bump で破壊的変更が
+  あり得る旨）。`CHANGELOG.md` を新設（Keep a Changelog 形式、現状は
+  `## [Unreleased]` のみ）し、`[project.urls]` に `Changelog` を追加
+- 未実施（今回のスコープ外、後続で実施）: `version = "0.1.0"` への更新、`v0.1.0` タグの
+  作成・push、TestPyPI/PyPI への実際の公開（PyPI 側の Trusted Publisher 事前登録が
+  ユーザー自身の作業として必要なため）
 
 ## フェーズ 4: 公開後の改善（ブロッカーではない）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 Homepage = "https://github.com/tmwork1/jpoke"
 Repository = "https://github.com/tmwork1/jpoke"
 Issues = "https://github.com/tmwork1/jpoke/issues"
+Changelog = "https://github.com/tmwork1/jpoke/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- `test.yml` に `package-check` ジョブを追加。`python -m build` → `twine check` → wheelインストール → リポジトリ外からの `import jpoke` を確認する。既存のCIは `pip install -e .`（editable）のみで、フェーズ1で見つかった致命的不具合（pokedex.jsonパッケージング漏れ）を検出できなかったため
- `publish.yml` を新設。`v*` タグのpushをトリガーに、Trusted Publishing（OIDC、`pypa/gh-action-pypi-publish`）でPyPIへ公開する build→publish の2ジョブ構成
- `CHANGELOG.md` を新設（Keep a Changelog形式）
- README・pyproject.tomlにsemverの方針とChangelogリンクを追記

`docs/plan/pypi_release.md` のフェーズ3のうち CI/ワークフロー整備部分に基づく変更です。

## 対象外（別途対応）
- `version` を 0.1.0 に上げること・`v0.1.0` タグの作成・実際のPyPI公開実行
- 理由: PyPI側でのTrusted Publisher事前登録（リポジトリ `tmwork1/jpoke` / workflow `publish.yml`）がユーザー自身の作業として必要なため

## Test plan
- [x] `test.yml` / `publish.yml` のYAML構文確認
- [x] package-checkジョブの内容（build → twine check → wheelインストール → import確認）をローカルで再現し成功を確認
- [x] `python -m pytest tests/ -q` 4821 passed, 1 skipped
- [x] `python -m ruff check src/ tests/ scripts/` 通過
- [ ] `publish.yml` の実際の動作確認は、PyPI側のTrusted Publisher登録後、初回リリース時に行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)