### PR TITLE
docs: READMEの想定用途メッセージングを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # jpoke
 
-ポケモンバトルシミュレーション開発用の Python ライブラリ。イベント駆動でポケモンの技・特性・アイテム・
-状態異常・場の効果などを再現し、bot 開発や乱数調整・ダメージ計算・木探索などの用途に使う。
+ポケモンチャンピオンズ（シングルバトル）準拠の対戦シミュレーション環境とダメージ計算ロジックを提供する
+Python ライブラリ。イベント駆動でポケモンの技・特性・アイテム・状態異常・場の効果などを再現し、
+戦術研究・AI 開発・ダメージ計算ツール開発などの用途を想定している。
 
-jpoke is an event-driven Python library for simulating Pokémon Champions single battles, reproducing
-moves, abilities, items, status conditions, and field effects. It targets bot development, RNG tuning,
-damage calculation, and tree search.
+jpoke is an event-driven Python library that provides a battle simulation environment and damage
+calculation logic for Pokémon Champions single battles, reproducing moves, abilities, items, status
+conditions, and field effects. It is intended for tactics research, AI development, and building
+damage calculation tools.
 
 > 本プロジェクトは株式会社ポケモン・任天堂・株式会社ゲームフリークとは無関係の非公式（fan-made）
 > プロジェクトです。
@@ -18,6 +20,8 @@ damage calculation, and tree search.
 - 技・特性・アイテム・ポケモンなどの仕様ソースは **第9世代（スカーレット・バイオレット）** を基本とし、
   ポケモンチャンピオンズ側でルールが異なる場合はそちらを優先する
 - 第9世代で実装されていない技・アイテム・特性・ポケモンなどは実装しない
+- ローカルでのシミュレーション・分析を目的としたライブラリであり、公式対戦での自動化（bot 運用）は
+  目的としていない。乱数調整もサポート対象外
 
 このプロジェクトの規約・アーキテクチャの詳細は
 [CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/CLAUDE.md) を参照（この README の対象範囲の

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jpoke"
 version = "0.1.0"
-description = "Event-driven Pokemon Champions single-battle simulation library (unofficial)"
+description = "Event-driven Pokemon Champions single-battle simulation and damage calculation library (unofficial)"
 authors = [
     { name = "Tomoo Mari", email = "tmtm.holmes@gmail.com" }
 ]
@@ -10,7 +10,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = []
-keywords = ["pokemon", "battle", "simulator", "bot"]
+keywords = ["pokemon", "battle", "simulator", "damage-calculator"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary
READMEの冒頭サマリ（日英）が想定用途として「bot開発・乱数調整」を挙げていたが、これは誤り:
- 公式シングルバトルでの bot（自動対戦プログラム）運用は公式利用規約違反にあたる
- 乱数調整（対戦中の乱数操作）はjpokeのサポート対象外

以下の観点で修正:
- 提供機能を「対戦シミュレーション環境」「ダメージ計算ロジック」の2本柱として明記
- 想定用途を「戦術研究・AI開発・ダメージ計算ツール開発」に統一（日英同趣旨）
- `## 対象範囲` にスコープ注記を追加（ローカルでのシミュレーション・分析目的であり、公式対戦での自動化は目的としない旨）
- 冒頭サマリで「ポケモンチャンピオンズ準拠」を主とし、第9世代はデータソースという主従関係を明確化（`## 対象範囲` の技術的記述自体は変更なし）
- `pyproject.toml` の `description`・`keywords`（`"bot"` → `"damage-calculator"`）も整合させた

## Test plan
- [x] README全文を通読し記述の一貫性を確認
- [x] `python -m pytest tests/ -q` 4821 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)