### PR TITLE
fix: core/model/data間の循環importの脆弱性を解消

### DIFF
--- a/docs/plan/pypi_release.md
+++ b/docs/plan/pypi_release.md
@@ -206,8 +206,16 @@ package-check:
   最低限 `Battle` / `Player` / `Pokemon` の公開 API を README か `docs/api/` にまとめる）
 - `tests/test_utils.py` の主要ヘルパー（`start_battle` / `run_move` / `run_switch`）を
   `jpoke.testing` として本体パッケージへ昇格
-- `core` ⇔ `model` ⇔ `data` の循環 import 解消（現状は `core/__init__.py` の
-  import 順序に依存して偶然動いている。順序を変えると ImportError が再発しうる）
+- 実施済み: `core` ⇔ `model` ⇔ `data` の循環 import 解消。パッケージ内の他ファイルが
+  `from jpoke.core import X` / `from jpoke.model import X` / `from jpoke.data import X` という
+  パッケージレベル絶対importを使い、対象パッケージの `__init__.py` が完全実行済みであることに
+  暗黙依存していた（約43箇所）。同一パッケージ内の自己参照は相対import（`from .context import X`）、
+  パッケージをまたぐ参照はサブモジュール直接指定の絶対import（`from jpoke.core.lethal import X` 等）に
+  書き換え、`__init__.py` の実行順序に依存しない形へ統一した。
+  実証実験: 修正前は `core/__init__.py` の `context` を `lethal` より前に並び替えると
+  `ImportError: cannot import name 'LethalHandler' from partially initialized module 'jpoke.core'`
+  が実際に発生することを確認。修正後は同じ並び替えを行っても `import jpoke` が成功することを確認済み
+  （実験用の並び替えはコミットに含めず、`core/__init__.py` は元の順序のまま）
 - `import jpoke` の初期化コスト削減（実測 約460ms。pokedex.json 544KB と
   全ハンドラテーブルを import 時に無条件ロードしている。遅延 import の余地あり）
 - CONTRIBUTING.md / SECURITY.md の整備

--- a/src/jpoke/core/ability_manager.py
+++ b/src/jpoke/core/ability_manager.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 from jpoke.utils import fast_copy
 from jpoke.types import AbilityDisabledReason, AbilityName
 from jpoke.enums import Event
-from jpoke.model import Ability
+from jpoke.model.ability import Ability
 from .context import EventContext
 
 

--- a/src/jpoke/core/ailment_manager.py
+++ b/src/jpoke/core/ailment_manager.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from jpoke.core import Battle, EventManager
 
-from jpoke.model import Pokemon, Ailment
+from jpoke.model.pokemon import Pokemon
+from jpoke.model.ailment import Ailment
 from jpoke.types import AilmentName
 from jpoke.enums import Event, LogCode
-from jpoke.core import EventContext, BaseContext
+from .context import EventContext, BaseContext
 from .log_payload import AilmentPayload
 from jpoke.utils import fast_copy
 

--- a/src/jpoke/core/battle.py
+++ b/src/jpoke/core/battle.py
@@ -21,7 +21,9 @@ from jpoke.exceptions import InvalidCommandError, InvalidPhaseError
 from jpoke.utils import fast_copy
 from jpoke.utils.math import round_half_down
 
-from jpoke.model import Pokemon, Move, Field
+from jpoke.model.pokemon import Pokemon
+from jpoke.model.move import Move
+from jpoke.model.field import Field
 
 from .player_state import PlayerState
 from .event_manager import EventManager

--- a/src/jpoke/core/command_manager.py
+++ b/src/jpoke/core/command_manager.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 from jpoke.utils import fast_copy
 from jpoke.types import BattlePhase, MoveName
 from jpoke.enums import Event, Command, Interrupt
-from jpoke.model import Move
+from jpoke.model.move import Move
 
 from .context import EventContext
 from .replay import RecordedCommand

--- a/src/jpoke/core/context.py
+++ b/src/jpoke/core/context.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from jpoke.model import Pokemon
 
 from jpoke.enums import Event
-from jpoke.model import Move
+from jpoke.model.move import Move
 from jpoke.types import RoleSpec, HPChangeReason, StatChangeReason
 
 

--- a/src/jpoke/core/damage.py
+++ b/src/jpoke/core/damage.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 from jpoke.enums import Event
 from jpoke.types import Stat
 from jpoke.utils import fast_copy
-from jpoke.data import TYPE_MODIFIER
+from jpoke.data.type_chart import TYPE_MODIFIER
 from jpoke.utils.math import round_half_down
 
 from .context import AttackContext

--- a/src/jpoke/core/field_manager.py
+++ b/src/jpoke/core/field_manager.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
 
 from jpoke.utils import fast_copy
 from jpoke.types import GlobalFieldName, SideFieldName, WeatherName, TerrainName
-from jpoke.data import WEATHER_PRIORITY
+from jpoke.data.field import WEATHER_PRIORITY
 from jpoke.enums import Event, LogCode
-from jpoke.model import Field
-from jpoke.core import EventContext
+from jpoke.model.field import Field
+from .context import EventContext
 from .log_payload import FieldPayload
 
 T = TypeVar("T")

--- a/src/jpoke/core/item_manager.py
+++ b/src/jpoke/core/item_manager.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 from jpoke.utils import fast_copy
 from jpoke.types import ItemDisabledReason, ItemName
 from jpoke.enums import Event, LogCode
-from jpoke.model import Pokemon, Item
+from jpoke.model.pokemon import Pokemon
+from jpoke.model.item import Item
 
 from .context import EventContext
 from .log_payload import ItemPayload

--- a/src/jpoke/core/move_executor.py
+++ b/src/jpoke/core/move_executor.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 from jpoke.types import Type, MoveCategory, MoveName
 from jpoke.utils.math import clamp_stats, clamp_critic
-from jpoke.model import Pokemon, Move
+from jpoke.model.pokemon import Pokemon
+from jpoke.model.move import Move
 from jpoke.enums import LogCode
 
 from .event_manager import Event

--- a/src/jpoke/core/observation_builder.py
+++ b/src/jpoke/core/observation_builder.py
@@ -6,7 +6,8 @@ if TYPE_CHECKING:
 
 from copy import deepcopy
 
-from jpoke.model import Ability, Item
+from jpoke.model.ability import Ability
+from jpoke.model.item import Item
 
 
 OBSERVED_MOVE_INDEXES: dict[Pokemon, dict[int, int]] = {}  # 技のインデックス変更を記録する辞書. dict[Pokemon, dict[old_index, new_index]]

--- a/src/jpoke/core/query.py
+++ b/src/jpoke/core/query.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
     from jpoke.core import Battle, EventManager, Player
     from jpoke.model import Move
 
-from jpoke.model import Pokemon
+from jpoke.model.pokemon import Pokemon
 from jpoke.enums import Event
-from jpoke.core import EventContext, AttackContext
+from .context import EventContext, AttackContext
 from jpoke.utils import fast_copy
 from jpoke.types import MoveCategory
 

--- a/src/jpoke/core/replay.py
+++ b/src/jpoke/core/replay.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 
 from jpoke.types import BattlePhase
 from jpoke.enums import Command
-from jpoke.model import Pokemon
+from jpoke.model.pokemon import Pokemon
 
 from .player import Player
 

--- a/src/jpoke/core/speed_calculator.py
+++ b/src/jpoke/core/speed_calculator.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from jpoke.model import Move
 
 from jpoke.enums import DomainEvent
-from jpoke.model import Pokemon
+from jpoke.model.pokemon import Pokemon
 from .context import EventContext, AttackContext
 from jpoke.utils import fast_copy
 

--- a/src/jpoke/core/status_manager.py
+++ b/src/jpoke/core/status_manager.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from jpoke.core import Battle, EventManager
 
-from jpoke.model import Pokemon
+from jpoke.model.pokemon import Pokemon
 from jpoke.types import Stat, HPChangeReason, StatChangeReason
 from jpoke.enums import Event, LogCode
-from jpoke.core import EventContext
+from .context import EventContext
 from jpoke.core.log_payload import HPChangePayload, StatChangePayload
 from jpoke.utils import fast_copy
 

--- a/src/jpoke/core/switch_manager.py
+++ b/src/jpoke/core/switch_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from . import Battle, EventManager, Player, PlayerState
 
-from jpoke.model import Pokemon
+from jpoke.model.pokemon import Pokemon
 from jpoke.enums import Interrupt, LogCode
 from jpoke.exceptions import InvalidCommandError
 

--- a/src/jpoke/core/turn_controller.py
+++ b/src/jpoke/core/turn_controller.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from jpoke.core import Battle, Player
 
-from jpoke.core import EventContext
+from .context import EventContext
 from jpoke.core.log_payload import TerastalPayload
 from jpoke.enums import Event, Command, Interrupt, LogCode
 from jpoke.utils import fast_copy

--- a/src/jpoke/core/volatile_manager.py
+++ b/src/jpoke/core/volatile_manager.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from jpoke.core import Battle, EventManager
 
-from jpoke.model import Pokemon, Volatile
+from jpoke.model.pokemon import Pokemon
+from jpoke.model.volatile import Volatile
 from jpoke.types import VolatileName
 from jpoke.enums import Event, LogCode
-from jpoke.core import EventContext
+from .context import EventContext
 from .log_payload import VolatilePayload
 from jpoke.utils import fast_copy
 

--- a/src/jpoke/data/ability.py
+++ b/src/jpoke/data/ability.py
@@ -5,7 +5,7 @@ Note:
 """
 
 from jpoke.enums import DomainEvent, Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.handlers import ability as h
 from jpoke.handlers import ability_paradox as paradox
 from jpoke.handlers import lethal as l

--- a/src/jpoke/data/ailment.py
+++ b/src/jpoke/data/ailment.py
@@ -1,5 +1,5 @@
 from jpoke.enums import DomainEvent, Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.handlers import ailment as h
 from jpoke.handlers import lethal as l
 from .models import AilmentData

--- a/src/jpoke/data/field/terrain.py
+++ b/src/jpoke/data/field/terrain.py
@@ -1,5 +1,5 @@
 from jpoke.enums import DomainEvent, Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.handlers import field as h
 from jpoke.handlers import lethal as l
 from ..models import FieldData

--- a/src/jpoke/data/field/weather.py
+++ b/src/jpoke/data/field/weather.py
@@ -1,5 +1,5 @@
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.handlers import field as h
 from jpoke.handlers import lethal as l
 from ..models import FieldData

--- a/src/jpoke/data/moves/move_a.py
+++ b/src/jpoke/data/moves/move_a.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_ha.py
+++ b/src/jpoke/data/moves/move_ha.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_ka.py
+++ b/src/jpoke/data/moves/move_ka.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_ma.py
+++ b/src/jpoke/data/moves/move_ma.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_ra.py
+++ b/src/jpoke/data/moves/move_ra.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_sa.py
+++ b/src/jpoke/data/moves/move_sa.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/moves/move_symbol.py
+++ b/src/jpoke/data/moves/move_symbol.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 from jpoke.utils.constants import PP_INFINITE
 

--- a/src/jpoke/data/moves/move_ta.py
+++ b/src/jpoke/data/moves/move_ta.py
@@ -5,7 +5,7 @@
 五十音順を維持すること。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.types import MoveName
 
 from jpoke.handlers import move as h

--- a/src/jpoke/data/volatile.py
+++ b/src/jpoke/data/volatile.py
@@ -4,7 +4,7 @@ Note:
     このモジュール内の揮発状態定義はVOLATILES辞書内で五十音順に配置されています。
 """
 from jpoke.enums import Event, LethalEvent
-from jpoke.core import LethalHandler
+from jpoke.core.lethal import LethalHandler
 from jpoke.handlers import volatile as h
 from jpoke.handlers import lethal as l
 from .models import VolatileData

--- a/src/jpoke/handlers/ability.py
+++ b/src/jpoke/handlers/ability.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 from jpoke.types import RoleSpec, Type, Stat, WeatherName, TerrainName, \
     AilmentName, VolatileName, ItemDisabledReason, MoveFlag, AbilityName, ItemName
 from jpoke.data.signature_items import PLATE_TO_TYPE, MEMORY_TO_TYPE
-from jpoke.data import TYPE_MODIFIER
+from jpoke.data.type_chart import TYPE_MODIFIER
 from jpoke.utils.math import apply_fixed_modifier
 from jpoke.enums import LogCode, Interrupt
-from jpoke.core import HandlerReturn, Handler
+from jpoke.core.handler import HandlerReturn, Handler
 from jpoke.core.log_payload import (
     AbilityPayload, AilmentPayload, VolatilePayload, FailureLogPayload,
     FieldPayload, ItemRevealPayload, MoveRevealPayload,

--- a/src/jpoke/handlers/ability_paradox.py
+++ b/src/jpoke/handlers/ability_paradox.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from jpoke.core import Battle, EventContext, AttackContext
     from jpoke.model import Pokemon
 
-from jpoke.core import HandlerReturn
+from jpoke.core.handler import HandlerReturn
 from jpoke.utils.math import apply_fixed_modifier
 from jpoke.types import BoostSource, Stat
 

--- a/src/jpoke/handlers/ailment.py
+++ b/src/jpoke/handlers/ailment.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 from jpoke.types import RoleSpec
 from jpoke.utils.math import apply_fixed_modifier
 from jpoke.enums import LogCode
-from jpoke.core import Handler, HandlerReturn
+from jpoke.core.handler import Handler, HandlerReturn
 from jpoke.core.log_payload import FailureLogPayload
 
 class AilmentHandler(Handler):

--- a/src/jpoke/handlers/field.py
+++ b/src/jpoke/handlers/field.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 from jpoke.enums import LogCode
 from jpoke.types import RoleSpec, GlobalFieldName, SideFieldName, VolatileName
 from jpoke.utils.math import apply_fixed_modifier
-from jpoke.core import HandlerReturn, Handler
+from jpoke.core.handler import HandlerReturn, Handler
 from jpoke.core.log_payload import FailureLogPayload
 
 class FieldHandler(Handler):

--- a/src/jpoke/handlers/item.py
+++ b/src/jpoke/handlers/item.py
@@ -13,9 +13,9 @@ from jpoke.types import RoleSpec, Stat, Type, MoveCategory, \
     AilmentName, WeatherName, TerrainName, SideFieldName
 from jpoke.utils.math import apply_fixed_modifier, round_half_down
 from jpoke.enums import Interrupt, LogCode, Command
-from jpoke.core import HandlerReturn, Handler
+from jpoke.core.handler import HandlerReturn, Handler
 from jpoke.core.log_payload import ItemPayload, StatChangePayload
-from jpoke.data import TYPE_MODIFIER
+from jpoke.data.type_chart import TYPE_MODIFIER
 from jpoke.data.megaevol import MEGA_STONES
 from jpoke.data.pokedex import POKEDEX
 from . import ability_paradox as paradox

--- a/src/jpoke/handlers/move.py
+++ b/src/jpoke/handlers/move.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from jpoke.core import Battle, AttackContext, Player
     from jpoke.types import RoleSpec, Stat, AilmentName, VolatileName
 
-from jpoke.core import Handler, HandlerReturn
+from jpoke.core.handler import Handler, HandlerReturn
 from jpoke.core.log_payload import FailureLogPayload
 from jpoke.enums import Command, LogCode
 

--- a/src/jpoke/handlers/move_attack.py
+++ b/src/jpoke/handlers/move_attack.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
     from jpoke.core import Battle, AttackContext, EventContext
 
 from jpoke.enums import Event, Interrupt, LogCode
-from jpoke.core import HandlerReturn
+from jpoke.core.handler import HandlerReturn
 from jpoke.core.log_payload import FailureLogPayload, VolatilePayload, StatChangePayload
 from jpoke.utils.math import apply_fixed_modifier, round_half_down, round_half_up
-from jpoke.data import TYPE_MODIFIER
+from jpoke.data.type_chart import TYPE_MODIFIER
 from jpoke.data.signature_items import PLATE_TO_TYPE
 from .move import (
     apply_ailment_to_defender,

--- a/src/jpoke/handlers/move_status.py
+++ b/src/jpoke/handlers/move_status.py
@@ -14,7 +14,7 @@ from .move import (
     modify_attacker_stats,
     modify_defender_stats,
 )
-from jpoke.core import HandlerReturn
+from jpoke.core.handler import HandlerReturn
 from jpoke.utils.math import round_half_down
 from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ from jpoke.utils.math import round_half_up
 
 from jpoke.enums import Event, Interrupt, LogCode
 from jpoke.core.log_payload import FailureLogPayload, ItemPayload, StatChangePayload
-from jpoke.data import TYPE_MODIFIER, TYPES
+from jpoke.data.type_chart import TYPE_MODIFIER, TYPES
 
 # バトンタッチで交代先に引き継ぐ揮発性状態の名前セット
 # docs/wiki/moves/バトンタッチ.html「状態変化の引き継ぎ」表（第9世代列）を正とする。

--- a/src/jpoke/handlers/volatile.py
+++ b/src/jpoke/handlers/volatile.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from jpoke.types import RoleSpec, Stat, AilmentName, VolatileName, MoveName
 
 from jpoke.enums import Event, Command, LogCode
-from jpoke.core import Handler, HandlerReturn
+from jpoke.core.handler import Handler, HandlerReturn
 from jpoke.core.log_payload import (
     VolatilePayload, FailureLogPayload, MoveActionPayload,
 )

--- a/src/jpoke/model/ability.py
+++ b/src/jpoke/model/ability.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from jpoke.data.ability import AbilityData
 
 from jpoke.utils import fast_copy
-from jpoke.data import ABILITIES
+from jpoke.data.ability import ABILITIES
 from jpoke.types import AbilityState, AbilityName
 
 from .effect import GameEffect

--- a/src/jpoke/model/item.py
+++ b/src/jpoke/model/item.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from jpoke.utils import fast_copy
-from jpoke.data import ITEMS
+from jpoke.data.item import ITEMS
 from jpoke.data.models import ItemData
 from jpoke.types import PokemonName, MoveName, ItemName
 

--- a/src/jpoke/model/move.py
+++ b/src/jpoke/model/move.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from jpoke.types import Type, MoveCategory, MoveFlag, MoveTarget, MoveName
 
 from jpoke.utils import fast_copy
-from jpoke.data import MOVES
+from jpoke.data.move import MOVES
 from jpoke.data.models import MoveData
 from .effect import GameEffect
 

--- a/src/jpoke/model/pokemon.py
+++ b/src/jpoke/model/pokemon.py
@@ -13,7 +13,9 @@ from jpoke.types import Nature, Type, Stat, Gender, HpPolicy, \
 from jpoke.utils.constants import STATS
 from jpoke.utils import math as m
 from jpoke.utils import fast_copy
-from jpoke.data import POKEDEX, MEGA_STONES, MEGA_POKEMONS, NATURE_MODIFIER
+from jpoke.data.pokedex import POKEDEX
+from jpoke.data.megaevol import MEGA_STONES, MEGA_POKEMONS
+from jpoke.data.nature import NATURE_MODIFIER
 
 from .ability import Ability
 from .item import Item


### PR DESCRIPTION
## Summary
`core`/`model`/`data`/`handlers` 配下の約43箇所が `from jpoke.core import X` のようなパッケージレベル絶対importを使っており、対象パッケージの `__init__.py` が完全実行済みであることに暗黙依存していた。実際に `core/__init__.py` の import順序（`context` を `lethal` より前にする等）を変えると `ImportError: cannot import name 'LethalHandler' from partially initialized module 'jpoke.core'` が発生することを実証。

修正方針:
- 同一パッケージ内の自己参照（例: `core/*.py` が `jpoke.core` を参照）→ 相対import（`from .context import EventContext`）
- パッケージをまたぐ参照（例: `data/ability.py` が `jpoke.core` を参照）→ サブモジュール直接指定の絶対import（`from jpoke.core.lethal import LethalHandler`、既に `data/item.py` が使っていた安全なパターンに統一）

`core/__init__.py` 等4つの `__init__.py` 自体（相対importで再エクスポートする既存パターン）は変更していない。

`docs/plan/pypi_release.md` のフェーズ4該当項目も実施済みに更新。

## Test plan
- [x] 修正前: `core/__init__.py` の順序を入れ替えて `ImportError` の再現を確認
- [x] 修正後: 同じ入れ替えを行っても `import jpoke` が成功することを確認（実験用の変更はコミットに含めず）
- [x] `python -m pytest tests/ -q` 4821 passed, 1 skipped（1回flaky失敗があったが再実行で解消、既知の乱数モック漏れ系で今回の変更とは無関係）
- [x] `python -m ruff check src/ tests/ scripts/` 通過
- [x] `python -m mypy` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)