### PR TITLE
Player.teamスナップショット警告とRandomPlayerを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   （`player_states[player].team` への直接アクセスを置き換える）
 - `Player.add_pokemon(name, **kwargs)` — `Pokemon` を直接importせずにチームへ
   ポケモンを追加できる正規ルート
+- `jpoke.players.RandomPlayer` — 合法手からランダムに選ぶ `Player` 実装。既定の
+  `Player.choose_command()`（常に先頭のコマンドを選ぶ決定的挙動）では
+  `battle_against()` による統計比較の分散が潰れてしまう問題への対応
 
 ### Changed
 

--- a/docs/plan/examples_api_feedback.md
+++ b/docs/plan/examples_api_feedback.md
@@ -26,7 +26,7 @@
 ## 公開APIの使い勝手
 
 - [x] `Player.team` への追加方法が `.append()`（01,03,05,06）と `= [...]` 代入（02,04）で混在。どちらも動くが教材として一貫性がなく、また `team` が素のlistのため6匹超過などの検証が入らない。`add_pokemon()` 等の正規ルートを1つ定めるか、examples内だけでも書式を統一したい。（→ 2026-07-11/12 `Player.add_pokemon()` を新設し、examples全体で統一）
-- [ ] `player.team` はコンストラクタ時点のスナップショットで対戦中は更新されず、対戦中の状態は `battle.get_active(player)` で取る必要がある（03のコメントで補足している通り）。「自分のチームなのに戦況が反映されない」のは学習者が最初に踏む罠で、docstringだけでなくAPIリファレンスでの明示が必要。（未対応: examples/03のコード内コメントのみで、`Player.team`属性のdocstring自体には未反映）
+- [x] `player.team` はコンストラクタ時点のスナップショットで対戦中は更新されず、対戦中の状態は `battle.get_active(player)` で取る必要がある（03のコメントで補足している通り）。「自分のチームなのに戦況が反映されない」のは学習者が最初に踏む罠で、docstringだけでなくAPIリファレンスでの明示が必要。（未対応: examples/03のコード内コメントのみで、`Player.team`属性のdocstring自体には未反映）（→ 2026-07-12 `Player` の `Attributes:` の `team` 説明にスナップショットである旨と `battle.get_active(player)` / `battle.get_team(player)` への誘導を追記）
 - [x] 場のポケモンの取得方法が `battle.get_active(player)`（03）と `battle.actives[0]`（04）の2通り登場する。相手チーム参照に至っては `battle.player_states[battle.opponent(self)].team`（05）と内部構造に踏み込んでおり、「外部APIはBattleの公開メソッドを入口にする」方針と齟齬がある。`battle.get_team(player)` のような公開アクセサが欲しい。（→ 2026-07-11 `Battle.get_team()` を新設し、examples全体で`get_active`/`get_team`に統一）
 - [x] `Pokemon.__init__` の暗黙デフォルトが多い: `nature="まじめ"`, `level=50`, `move_names` 省略時は `["はねる"]`, `ability_name=""`, IV31/EV0。特に「技を渡さないとはねるになる」「特性が空文字で何になるか」はコードから読み取れず、docstringでの明記かクラスメソッド（例: `Pokemon.simple(...)`）での整理を検討したい。（→ 2026-07-11 docstringに明記して対応。代替コンストラクタは`add_pokemon()`が実質的に代替するため追加実装は見送り）
 - [x] `n_selected` のデフォルト3とチーム1匹構成の組み合わせは、01のように毎回 `n_selected=1` を明示する必要がある。省略時に「min(3, len(team))に自動調整」する方が導入体験は滑らか。（→ 2026-07-11 自動調整を実装）
@@ -35,7 +35,7 @@
 ## 既知のバグ・要修正候補
 
 - [x] `Battle(seed=None)` が `int(time.time())`（秒精度）にフォールバックする（`src/jpoke/core/battle.py:155`）。`battle_against(n_battles=30)` をseed省略で呼ぶと30戦全てが同一seedになり勝率が0%/100%に張り付く。対応案: (1) フォールバックを `time.time_ns()` または `Random(None)`（OSエントロピー）に変更、(2) `battle_against` 側で `seed` 指定時は対局ごとに `seed+i` の派生seedを振る。両方入れれば `examples/06` のワークアラウンド（n_battles=1×ループ）を素直な `battle_against(..., n_battles=30)` に書き戻せる。（→ 2026-07-11 `secrets.randbits(32)` に変更 + `battle_against`の対局別seed派生を実装）
-- [ ] デフォルト `Player.choose_command()` が「利用可能なコマンドの先頭を選ぶ」決定的挙動である点は、seedを変えても同一展開になりやすく、06のような統計比較の分散を殺す方向に働く。ベースラインとしてランダム選択（05の `RandomPlayer` 相当）を標準提供するか、既定挙動をdocstringで強調すべき。（未対応）
+- [x] デフォルト `Player.choose_command()` が「利用可能なコマンドの先頭を選ぶ」決定的挙動である点は、seedを変えても同一展開になりやすく、06のような統計比較の分散を殺す方向に働く。ベースラインとしてランダム選択（05の `RandomPlayer` 相当）を標準提供するか、既定挙動をdocstringで強調すべき。（未対応）（→ 2026-07-12 `jpoke.players.RandomPlayer` を新設（`battle.random` ベースで `Battle(seed=...)` の再現性を保つ）。examples/05のローカル定義を置き換え、`Player.choose_command()` のdocstringにも既定実装が決定的である旨と `RandomPlayer` への誘導を追記）
 
 ## 優先度メモ
 
@@ -90,3 +90,30 @@
 ### 2026-07-12 再レビュー対応
 
 PR #38 の差分に対して再度Fableモデルでレビューを受け、上記「再レビュー指摘」の内容を修正した。
+
+### 2026-07-12 残り2項目の実装（`player.team`スナップショット警告 + `RandomPlayer`新設）
+
+- `Player`（`src/jpoke/core/player.py`）の `Attributes:` の `team` 説明に、対戦中は
+  更新されないスナップショットであることと、対戦中の実際の状態は
+  `battle.get_active(player)` / `battle.get_team(player)` を使うべき旨を追記
+- `src/jpoke/players/random_player.py` に `RandomPlayer(Player)` を新設。
+  `battle.random.choice(battle.get_available_commands(self))` で選ぶ実装で、
+  `examples/05_tree_search_ai.py` に元々ローカル定義されていたものと同等
+  （`battle.random` を使うため `Battle(seed=...)` の再現性を壊さない）
+- `src/jpoke/players/__init__.py` に `RandomPlayer` を追加してエクスポート
+- `Player.choose_command()` のdocstringに、既定実装が決定的（常に先頭のコマンドを
+  選ぶ）である旨と、統計比較などで分散が必要な場合は `jpoke.players.RandomPlayer`
+  を使うとよい旨を追記
+- `examples/05_tree_search_ai.py` のローカル `RandomPlayer` 定義を削除し、
+  `from jpoke.players import RandomPlayer` に置き換え（未使用になった `Player` /
+  `Command` importも削除）
+- `CHANGELOG.md` の `[Unreleased]` / `### Added` に `RandomPlayer` の追加を記載
+- `tests/test_poke_env_compat.py` に `RandomPlayer` のテストを2件追加
+  （選択コマンドが常に `get_available_commands()` に含まれること、
+  `battle.random` 経由で同一seedなら同一コマンド列を再現すること）。
+  `scripts/sort_tests.py` / `scripts/generate_test_list.py` を実行し、
+  フルテストスイートを3回連続実行して全件成功・非flakyを確認済み
+  （worktree分離環境ではeditable installが別チェックアウトの`src`を指すため、
+  `tests/test_examples_smoke.py`（サブプロセス起動によるスモークテスト）を
+  検証する際は `PYTHONPATH=<worktree>/src` を明示してworktree内の実装を
+  優先させる必要があった。mainマージ後は不要な手当て）

--- a/docs/tests/test_poke_env_compat.md
+++ b/docs/tests/test_poke_env_compat.md
@@ -1,6 +1,6 @@
 # test_poke_env_compat
 
-テスト数: 36
+テスト数: 38
 
 - [x] battle_active_pokemonとopponent_active_pokemonはobserver未設定時場の先頭2匹を返す
 - [x] battle_active_pokemonとopponent_active_pokemonはobserver視点で取得できる
@@ -34,6 +34,8 @@
 - [x] pokemon_effectsはvolatilesのエイリアス
 - [x] pokemon_first_turnは登場直後True行動後False
 - [x] pokemon_statusはailment_nameのエイリアス
+- [x] randomplayerが選ぶコマンドは常にget_available_commandsに含まれる
+- [x] randomplayerは同じseedで対戦すると同じコマンド列を再現する
 - [x] stat_indexはhpからspeまでの6ステータスを網羅する
 - [x] stats_from_poke_envは欠けているキーを0扱いにする
 - [x] stats_from_poke_envは辞書をhp_atk_def_spa_spd_spe順のリストに変換する

--- a/examples/05_tree_search_ai.py
+++ b/examples/05_tree_search_ai.py
@@ -9,20 +9,9 @@ AI開発ユースケースの発展形。
 """
 from __future__ import annotations
 
-from jpoke import Battle, Player
-from jpoke.enums import Command
+from jpoke import Battle
+from jpoke.players import RandomPlayer
 from jpoke.players.tree_search_player import TreeSearchPlayer
-
-
-class RandomPlayer(Player):
-    """比較対象として使う、合法手からランダムに選ぶだけのプレイヤー。
-
-    battle.random（各対戦固有の乱数系列）を使うため、Battle(seed=...) による
-    再現性を壊さない。
-    """
-
-    def choose_command(self, battle: Battle) -> Command:
-        return battle.random.choice(battle.get_available_commands(self))
 
 
 class KOFocusedPlayer(TreeSearchPlayer):

--- a/src/jpoke/core/player.py
+++ b/src/jpoke/core/player.py
@@ -22,7 +22,11 @@ class Player:
 
     Attributes:
         username: プレイヤー名
-        team: ポケモンチームのリスト（最大6匹）
+        team: ポケモンチームのリスト（最大6匹）。**コンストラクタ〜対戦開始前の
+            スナップショット**であり、`Battle` 開始後の対戦中はここに反映される
+            HP・瀕死・状態異常・ランク変化などは更新されない。対戦中の実際の
+            状態を見たい場合は `battle.get_active(player)`（場に出ている
+            ポケモン）や `battle.get_team(player)`（チーム全体の実体）を使う。
         n_finished_battles: 対戦数
         n_won_battles: 勝利数
         rating: レーティング値
@@ -118,7 +122,10 @@ class Player:
     def choose_command(self, battle: Battle) -> Command:
         """コマンドを選択する。
 
-        デフォルト実装では利用可能な行動コマンドの最初の1つを返す。
+        デフォルト実装では利用可能な行動コマンドの最初の1つを返す。この既定実装は
+        決定的（常に先頭のコマンドを選ぶ）で、`seed` を変えても展開が変わらない。
+        `Player.battle_against()` で複数回対戦して統計比較する場合など、行動選択に
+        分散が必要な場合は `jpoke.players.RandomPlayer` を使うとよい。
 
         Args:
             battle: バトルオブジェクト

--- a/src/jpoke/players/__init__.py
+++ b/src/jpoke/players/__init__.py
@@ -1,9 +1,10 @@
 """`Player` の派生方策実装を集約するパッケージ。
 
-木探索ベースの `TreeSearchPlayer` など、bot・探索コードから再利用される
-方策実装をここに置く。
+木探索ベースの `TreeSearchPlayer`、ランダム選択の `RandomPlayer` など、
+bot・探索コードから再利用される方策実装をここに置く。
 リプレイ再生用の `ReplayPlayer` / `replay_battle()` は `jpoke.core.replay` を参照。
 """
 from .tree_search_player import TreeSearchPlayer
+from .random_player import RandomPlayer
 
-__all__ = ["TreeSearchPlayer"]
+__all__ = ["TreeSearchPlayer", "RandomPlayer"]

--- a/src/jpoke/players/random_player.py
+++ b/src/jpoke/players/random_player.py
@@ -1,0 +1,24 @@
+"""合法手からランダムに選ぶだけのプレイヤー。
+
+`Player.choose_command()` の既定実装（常に先頭のコマンドを選ぶ決定的挙動）の
+代わりに使う、統計比較・ベースライン対戦向けの標準実装。
+"""
+from __future__ import annotations
+
+from jpoke import Battle, Player
+from jpoke.enums import Command
+
+
+class RandomPlayer(Player):
+    """比較対象・ベースラインとして使う、合法手からランダムに選ぶだけのプレイヤー。
+
+    `battle.random`（各対戦固有の乱数系列）を使って選ぶため、`Battle(seed=...)`
+    による再現性を壊さない。`Player.battle_against()` で複数回対戦して統計比較
+    する場合、既定の `Player.choose_command()`（常に先頭のコマンドを選ぶ決定的
+    挙動）では展開の分散が潰れてしまうため、対戦相手やベースラインとして
+    このクラスを使うとよい。
+    """
+
+    def choose_command(self, battle: Battle) -> Command:
+        """利用可能なコマンドから `battle.random` でランダムに1つ選ぶ。"""
+        return battle.random.choice(battle.get_available_commands(self))

--- a/tests/test_poke_env_compat.py
+++ b/tests/test_poke_env_compat.py
@@ -7,9 +7,10 @@ from typing import get_args
 
 import pytest
 
-from jpoke.core import Player
+from jpoke.core import Battle, Player
 from jpoke.core.player import MAX_TURNS
 from jpoke.model import Pokemon, Move
+from jpoke.players import RandomPlayer
 from jpoke.types import (
     AilmentName, GlobalFieldName, Nature, SideFieldName, TerrainName, Type, WeatherName,
 )
@@ -341,6 +342,70 @@ def test_pokemon_statusはailment_nameのエイリアス():
 
     assert mon.status == "やけど"
     assert mon.status == mon.ailment.name
+
+
+def test_randomplayerが選ぶコマンドは常にget_available_commandsに含まれる():
+    """RandomPlayer.choose_command() の戻り値が、選択時点の合法手
+    （battle.get_available_commands()）に必ず含まれることを確認する。
+
+    choose_command()の呼び出し前後で合法手が変化しないことを保証するため、
+    RandomPlayerを継承したクラスで呼び出し直前の合法手を記録し、実際の対戦
+    （battle.step()）を通じて検証する。
+    """
+    class _RecordingRandomPlayer(RandomPlayer):
+        def __init__(self, username: str):
+            super().__init__(username)
+            self.checked: list[bool] = []
+
+        def choose_command(self, battle: "Battle"):
+            available = battle.get_available_commands(self)
+            command = super().choose_command(battle)
+            self.checked.append(command in available)
+            return command
+
+    p0 = _RecordingRandomPlayer("p0")
+    p0.add_pokemon("ピカチュウ", move_names=["でんきショック", "でんこうせっか", "アイアンテール"])
+    p1 = _RecordingRandomPlayer("p1")
+    p1.add_pokemon("ゼニガメ", move_names=["みずでっぽう", "たいあたり"])
+
+    battle = Battle((p0, p1), seed=1)
+    battle.start()
+
+    for _ in range(5):
+        if battle.judge_winner() is not None:
+            break
+        battle.step()
+
+    assert p0.checked and all(p0.checked)
+    assert p1.checked and all(p1.checked)
+
+
+def test_randomplayerは同じseedで対戦すると同じコマンド列を再現する():
+    """RandomPlayer は battle.random（Battle(seed=...) に紐づく乱数系列）を使って
+    選ぶため、同じseedで対戦を最初からやり直すと同じコマンド列（battle.command_log）
+    を再現できることを確認する。グローバルなrandomモジュールに依存していれば
+    プロセス内の他の乱数消費と競合してこの再現性が崩れるため、battle.random を
+    使っている（＝Battle(seed=...)による再現性を壊さない）ことの検証になる。
+    """
+    def run(seed: int) -> list:
+        p0 = RandomPlayer("p0")
+        p0.add_pokemon("ピカチュウ", move_names=["でんきショック", "でんこうせっか", "アイアンテール"])
+        p1 = RandomPlayer("p1")
+        p1.add_pokemon("ゼニガメ", move_names=["みずでっぽう", "たいあたり"])
+
+        battle = Battle((p0, p1), seed=seed)
+        battle.start()
+        for _ in range(5):
+            if battle.judge_winner() is not None:
+                break
+            battle.step()
+        return list(battle.command_log)
+
+    log_a = run(12345)
+    log_b = run(12345)
+
+    assert log_a == log_b
+    assert len(log_a) > 0
 
 
 def test_stat_indexはhpからspeまでの6ステータスを網羅する():


### PR DESCRIPTION
## Summary
- `docs/plan/examples_api_feedback.md` に残っていた未対応2項目を実装
  - `Player.team` が対戦開始前のスナップショットで対戦中は更新されないことを `Attributes:` に明記し、`battle.get_active(player)` / `battle.get_team(player)` への誘導を追加
  - `jpoke.players.RandomPlayer` を新設（`battle.random` ベースで `Battle(seed=...)` の再現性を保つ）。既定の `Player.choose_command()`（常に先頭のコマンドを選ぶ決定的挙動）では統計比較の分散が潰れる問題への対応。`Player.choose_command()` のdocstringにも誘導を追記
  - `examples/05_tree_search_ai.py` のローカル `RandomPlayer` 定義を `jpoke.players.RandomPlayer` のimportに置き換え

## Test plan
- [x] `tests/test_poke_env_compat.py` に `RandomPlayer` のテストを2件追加（合法手内から選ぶこと、同一seedでの再現性）。いずれも同一バトルの自己比較のみで、異なるseed間のダメージ比較のようなflaky要因は含まない
- [x] `python -m pytest tests/ -v` をこのブランチのマージ後の状態を想定して複数回実行し、全件成功・非flakyを確認
- [x] `scripts/sort_tests.py` / `scripts/generate_test_list.py` 実行済み

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>