### PR TITLE
docs: READMEから英語説明文を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,8 @@
 ポケモンチャンピオンズ準拠のシングル対戦シミュレーション環境とダメージ計算ロジックを提供する
 Python ライブラリ。イベント駆動でポケモンの技・特性・アイテム・状態異常・場の効果などを再現している。戦術研究・AI 開発・ダメージ計算ツール開発などの用途を想定している。
 
-jpoke is a Python library that provides a single-battle simulation environment and damage calculation
-logic compliant with Pokémon Champions rules. It reproduces moves, abilities, items, status conditions,
-and field effects in an event-driven manner. It is intended for use cases such as tactics research,
-AI development, and building damage calculation tools.
-
 > 本プロジェクトは株式会社ポケモン・任天堂・株式会社ゲームフリークとは無関係の非公式（fan-made）
 > プロジェクトです。
-> This is an unofficial, fan-made project and is not affiliated with, endorsed by, or sponsored by
-> Nintendo, Game Freak, or The Pokémon Company.
 
 ## 対象範囲
 


### PR DESCRIPTION
## Summary
- 日本語利用のみを想定しているため、README.mdの英語版の紹介文（概要説明・免責事項）を削除

## Test plan
- ドキュメントのみの変更のためテスト実行なし