### PR TITLE
examples: janken_nashのポケモン・技構成を自由に変更可能に

### DIFF
--- a/examples/04_research/03_janken_nash_fictitious_play.py
+++ b/examples/04_research/03_janken_nash_fictitious_play.py
@@ -1,29 +1,19 @@
 """jpoke で学べること: 実際のバトルシミュレーションからNash均衡（混合戦略）を近似する。
 
-## 題材: エビワラー（てつのこぶし）の「技の三すくみ」
+## 題材
 
-このサンプルは、エビワラーに以下の3つの技だけを覚えさせ、毎ターンどの技を
-選ぶかという読み合いを扱う。
+1体・3つの技だけで対戦させ、「毎ターンどの技を何%の確率で選ぶか」という
+混合戦略（mixed strategy）のNash均衡を近似する。3つの技がじゃんけんのような
+三すくみの関係にある場合、単一の技を固定で使い続ける戦略は必ず弱点を突かれるため、
+確率配分の設計が課題になる。両者がこれ以上一方的に得をする変更をする余地がない
+状態を Nash均衡 と呼ぶ。
 
-* マッハパンチ（優先度+1）: 先制で殴る。追加効果なし
-* はやてがえし（優先度+3）: 相手が「先制攻撃技」を選んでいるときだけ成功し、
-  それより先に動いてひるませる。相手が優先度の低い技（きあいパンチ等）を
-  選んでいた場合は不発に終わる
-* きあいパンチ（優先度-3）: 通常は最後に動くが、行動前にダメージを受けなければ
-  威力150の一撃が確定する。逆に行動前にダメージを受けると不発になる
-
-この3つは、じゃんけんのような三すくみの関係になる:
-
-* マッハパンチ は きあいパンチ に勝つ（先制で殴ってしまうため、きあいパンチが
-  「行動前にダメージを受けた」扱いになり不発する）
-* はやてがえし は マッハパンチ に勝つ（マッハパンチも先制技なので、はやてがえし
-  の判定条件を満たし、より優先度の高いはやてがえしが先にひるませてしまう）
-* きあいパンチ は はやてがえし に勝つ（はやてがえしは非先制技には不発するので、
-  きあいパンチ側はダメージを受けずに行動でき、そのまま全力の一撃を通せる）
-
-じゃんけんと同様、単一の技を固定で使い続ける戦略は必ず弱点を突かれるため、
-「どの技を何%の確率で選ぶか」という混合戦略（mixed strategy）の設計が課題になる。
-両者がこれ以上一方的に得をする変更をする余地がない状態を Nash均衡 と呼ぶ。
+対戦するポケモン・技3つはファイル先頭の「対戦相手の構成」で指定する。既定値
+（マッハパンチ/はやてがえし/きあいパンチを覚えたエビワラー）が三すくみになる
+理由など技の仕様の詳細は `docs/spec/moves/` の各技の仕様書を参照。ここを別の
+ポケモン・技3つに書き換えれば、そちらの読み合いでも同じように均衡を近似できる
+（アルゴリズム自体は技の内容に依存しない。ただし戦略を3次元の確率分布として
+扱うため、技はちょうど3つである必要がある）。
 
 ## このスクリプトのアプローチ
 
@@ -64,13 +54,21 @@ from typing import Iterable
 from jpoke import Battle, Player, Pokemon
 from jpoke.enums import Command
 
+# ---- 対戦相手の構成 ----
+# ここを書き換えるだけで、別のポケモン・技3つの読み合いに変更できる
+# （MOVES はちょうど3つ指定する）
+SPECIES_NAME = "エビワラー"
+ABILITY_NAME = "てつのこぶし"
+NATURE = "いじっぱり"
 MOVES = ["マッハパンチ", "はやてがえし", "きあいパンチ"]
+EVS = [0, 0, 0, 0, 0, 0]
+IVS = [31, 31, 31, 31, 31, 31]
 
 # ---- 実行設定 ----
 # 実行時間を抑えつつ動作を確認できる値にしてある。本格的な精度が欲しい場合は
 # モジュールdocstringの「精度とデータ量のトレードオフ」を参照して値を大きくする
 BASE_SEED = 20260323
-MAX_TURNS = 10  # 1ゲームあたりの最大ターン数（この技構成なら大抵は数ターンで決着する）
+MAX_TURNS = 10  # 1ゲームあたりの最大ターン数
 
 EVAL_TRIALS = 15  # 戦略ペアの勝率を推定する試行回数。大きいほど精密だが計算量が増える
 GRID_STEP = 0.25  # 混合戦略の候補を生成するグリッドの刻み幅。小さいほど精密だが計算量が増える
@@ -91,7 +89,7 @@ class MixedMovePlayer(Player):
 
     def __init__(self, probs: tuple[float, float, float], username: str = ""):
         super().__init__(username)
-        self.probs = probs  # (マッハパンチ, はやてがえし, きあいパンチ) を選ぶ確率
+        self.probs = probs  # MOVES の3つの技を選ぶ確率（順に対応）
 
     def choose_command(self, battle: Battle) -> Command:
         r = battle.decision_random.random()
@@ -100,19 +98,14 @@ class MixedMovePlayer(Player):
             return Command.MOVE_0
         if r < p0 + p1:
             return Command.MOVE_1
-        return Command.MOVE_2  # 残りの確率（1 - p0 - p1）はきあいパンチ
+        return Command.MOVE_2  # 残りの確率（1 - p0 - p1）
 
 
-def make_hitmonchan() -> Pokemon:
-    """3すくみの技だけを覚えたエビワラーを1体構築する。"""
-    mon = Pokemon(
-        "エビワラー",
-        ability_name="てつのこぶし",  # パンチ技（マッハパンチ）の威力を1.2倍にする特性
-        nature="いじっぱり",
-        move_names=MOVES,
-    )
-    mon.set_evs([0, 0, 0, 0, 0, 0])
-    mon.set_ivs([31, 31, 31, 31, 31, 31], hp_policy="reset")  # 新規構築なので満タンにする
+def build_pokemon() -> Pokemon:
+    """「対戦相手の構成」から対戦用ポケモンを1体構築する。"""
+    mon = Pokemon(SPECIES_NAME, ability_name=ABILITY_NAME, nature=NATURE, move_names=MOVES)
+    mon.set_evs(EVS)
+    mon.set_ivs(IVS, hp_policy="reset")  # 新規構築なので満タンにする
     return mon
 
 
@@ -129,8 +122,8 @@ def play_game(row_probs: tuple[float, float, float],
     """
     p0 = MixedMovePlayer(row_probs, username="p0")
     p1 = MixedMovePlayer(col_probs, username="p1")
-    p0.team.append(make_hitmonchan())
-    p1.team.append(make_hitmonchan())
+    p0.team.append(build_pokemon())
+    p1.team.append(build_pokemon())
 
     battle = Battle(p0, p1, seed=seed)
     battle.test_option.accuracy = 100  # 命中率のブレを消し、技選択の駆け引きだけを見る
@@ -337,7 +330,7 @@ def main() -> None:
     workers = N_WORKERS if N_WORKERS is not None else max(1, (os.cpu_count() or 1) - 1)
 
     candidates = simplex_grid(GRID_STEP)
-    print("=== Hitmonchan Janken Nash Approx ===")
+    print(f"=== {SPECIES_NAME} Janken Nash Approx ({'/'.join(MOVES)}) ===")
     print(f"candidates={len(candidates)}, step={GRID_STEP}, iter={ITERATIONS}, trials={EVAL_TRIALS}, workers={workers}")
 
     with ProcessPoolExecutor(max_workers=workers) as executor:
@@ -357,8 +350,9 @@ def main() -> None:
 
     # 試してみよう:
     # * GRID_STEP / EVAL_TRIALS / ITERATIONS を大きくして、結果がどれだけ安定するか比較する
-    # * MOVES の並び順や技構成を変えて、別の三すくみ・じゃんけんにならない組み合わせで
-    #   どう均衡が変わるか（あるいは支配戦略が生まれるか）を観察する
+    # * ファイル先頭の「対戦相手の構成」で別のポケモン・技3つに変えて、
+    #   三すくみになる組み合わせ・ならない組み合わせでどう均衡が変わるか
+    #   （あるいは支配戦略が生まれるか）を観察する
     # * 他のNash均衡の求め方との比較:
     #   このスクリプトは「候補戦略を格子状に列挙し、反復最適反応で均衡へ近づける」という
     #   汎用的だが計算量の大きい方法を使っている。もし「1ターンだけの技同士の勝率」が

--- a/examples/04_research/04_janken_nash_cfr.py
+++ b/examples/04_research/04_janken_nash_cfr.py
@@ -4,18 +4,19 @@
 
 `03_janken_nash_fictitious_play.py` は「毎ターン同じ確率で技を選び続ける」固定の混合戦略の
 Nash均衡を求めた。しかし実戦の読み合いはもっと現実的で、「自分のHPが少ない
-ときはリスクを避けて確実なマッハパンチを選ぶ」「相手を追い詰めたら一発逆転の
-きあいパンチを警戒してはやてがえしを増やす」といった、局面（HP状況）に応じて
-確率を変える適応的な戦略の方が強くなりうる。このサンプルは、その「状態に
-応じた戦略」を自己対戦から学習する。
+ときはリスクを避けて手堅い技を選ぶ」「相手を追い詰めたら一発逆転を警戒して
+別の技を増やす」といった、局面（HP状況）に応じて確率を変える適応的な戦略の
+方が強くなりうる。このサンプルは、その「状態に応じた戦略」を自己対戦から
+学習する。対戦するポケモン・技3つはファイル先頭の「対戦相手の構成」で指定する
+（03と同じ既定値・同じ制約。詳細は03のモジュールdocstring「題材」を参照）。
 
 ## 状態（information set）の定義
 
 状態は `(自分のHP割合バケット, 相手のHP割合バケット)` の組で表す
 （`HP_BUCKETS` 段階に離散化。既定は3段階 = 「多い/中/少ない」）。
 ターン数などは状態に含めない単純化をしている（詳しくは `hp_bucket()` 参照）。
-この状態ごとに「マッハパンチ/はやてがえし/きあいパンチをそれぞれ何%選ぶか」
-という戦略テーブルを学習する。
+この状態ごとに「MOVES の3つの技をそれぞれ何%選ぶか」という戦略テーブルを
+学習する。
 
 ## アルゴリズム: ロールアウトベースのregret matching（CFR風）
 
@@ -63,7 +64,16 @@ from collections import defaultdict
 from jpoke import Battle, Player, Pokemon
 from jpoke.enums import Command
 
+# ---- 対戦相手の構成 ----
+# ここを書き換えるだけで、別のポケモン・技3つの読み合いに変更できる
+# （MOVES はちょうど3つ指定する。03と同じ制約）
+SPECIES_NAME = "エビワラー"
+ABILITY_NAME = "てつのこぶし"
+NATURE = "いじっぱり"
 MOVES = ["マッハパンチ", "はやてがえし", "きあいパンチ"]
+EVS = [0, 0, 0, 0, 0, 0]
+IVS = [31, 31, 31, 31, 31, 31]
+
 MOVE_COMMANDS = (Command.MOVE_0, Command.MOVE_1, Command.MOVE_2)
 
 # ---- 実行設定 ----
@@ -115,16 +125,11 @@ def add_vec(a: tuple[float, float, float], b: tuple[float, float, float]) -> tup
     return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
 
 
-def make_hitmonchan() -> Pokemon:
-    """3すくみの技だけを覚えたエビワラーを1体構築する。"""
-    mon = Pokemon(
-        "エビワラー",
-        ability_name="てつのこぶし",  # パンチ技（マッハパンチ）の威力を1.2倍にする特性
-        nature="いじっぱり",
-        move_names=MOVES,
-    )
-    mon.set_evs([0, 0, 0, 0, 0, 0])
-    mon.set_ivs([31, 31, 31, 31, 31, 31], hp_policy="reset")  # 新規構築なので満タンにする
+def build_pokemon() -> Pokemon:
+    """「対戦相手の構成」から対戦用ポケモンを1体構築する。"""
+    mon = Pokemon(SPECIES_NAME, ability_name=ABILITY_NAME, nature=NATURE, move_names=MOVES)
+    mon.set_evs(EVS)
+    mon.set_ivs(IVS, hp_policy="reset")  # 新規構築なので満タンにする
     return mon
 
 
@@ -199,8 +204,8 @@ def play_training_episode(regrets: dict[tuple[int, int], list[float]],
     """
     p0 = CFRMovePlayer(regrets, username="p0")
     p1 = CFRMovePlayer(regrets, username="p1")
-    p0.team.append(make_hitmonchan())
-    p1.team.append(make_hitmonchan())
+    p0.team.append(build_pokemon())
+    p1.team.append(build_pokemon())
 
     battle = Battle(p0, p1, seed=seed)
     battle.test_option.accuracy = 100  # 命中率のブレを消し、技選択の駆け引きだけを見る
@@ -254,7 +259,7 @@ def main() -> None:
     strategy_sums: dict[tuple[int, int], tuple[float, float, float]] = defaultdict(lambda: (0.0, 0.0, 0.0))
     visit_counts: dict[tuple[int, int], int] = defaultdict(int)
 
-    print("=== Hitmonchan Janken CFR-style Self-play ===")
+    print(f"=== {SPECIES_NAME} Janken CFR-style Self-play ({'/'.join(MOVES)}) ===")
     print(f"episodes={N_EPISODES}, hp_buckets={HP_BUCKETS}, max_turns={MAX_TURNS}")
 
     row_wins = 0.0
@@ -278,8 +283,8 @@ def main() -> None:
     # 試してみよう:
     # * HP_BUCKETS を増やす、または状態にターン数を加えると、より細かい読み合いを
     #   学習できるが、その分エピソード数(N_EPISODES)を増やさないと学習が安定しない
-    # * 03_janken_nash_fictitious_play.py の固定混合戦略の結果と比較し、「HPが少ないときだけ
-    #   マッハパンチに偏る」といった適応的な傾向が出ているか観察する
+    # * 03_janken_nash_fictitious_play.py の固定混合戦略の結果と比較し、「own（自分HP）が
+    #   少ない状態だけ特定の技に偏る」といった適応的な傾向が出ているか観察する
     # * rollout_value() の呼び出しを毎回1回ではなく複数回平均するようにすると、
     #   反実仮想価値の推定分散が減り学習が安定するが、実行時間は増える
 


### PR DESCRIPTION
## Summary
PR #52（examples/ディレクトリ構造化前の旧パス向け）の内容を、新パス
（`examples/04_research/03_janken_nash_fictitious_play.py` /
`examples/04_research/04_janken_nash_cfr.py`）に移植した。PR #52は
このPRのマージ後にクローズする。

- `examples/04_research/03_janken_nash_fictitious_play.py` /
  `04_janken_nash_cfr.py` のdocstring/コメントから、エビワラー固有の
  技の優先度・不発条件などの詳細説明を省き、「三すくみのような読み合いの
  Nash均衡を近似する」という一般論のみ残した
- 種族名・特性・性格・技・努力値・個体値をファイル先頭の「対戦相手の構成」
  ブロック（`SPECIES_NAME`/`ABILITY_NAME`/`NATURE`/`MOVES`/`EVS`/`IVS`）に集約
- `make_hitmonchan()` を `build_pokemon()` に汎用化し、出力ヘッダーも動的生成に変更
- これにより、別のポケモン・技3つに書き換えるだけでそのまま動く

## Test plan
- [x] `python examples/04_research/03_janken_nash_fictitious_play.py` /
      `04_janken_nash_cfr.py` を実行し、新しいヘッダー・戦略出力が正しく表示されることを確認
- [x] `python -m pytest tests/ -q` — 4839 passed, 1 skipped
- [x] `python -m ruff check examples/` — 全件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)