### PR TITLE
docs: 利用者向けAPIリファレンス（docs/api/README.md）を新設

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ battle.print_logs()                 # このターンのログを表示
 
 | ディレクトリ | 役割 |
 |---|---|
+| `docs/api/` | 利用者向け公開APIリファレンス（`Battle` / `Player` / `Pokemon`） |
 | `docs/spec/` | 技・アイテム・特性・場の効果の挙動仕様 |
 | `docs/plan/` | 実行計画と優先順位 |
 | `docs/progress/` | カテゴリ別の実装追跡（`ability.md`, `item.md`, `move.md` 等） |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,366 @@
+# jpoke API リファレンス
+
+`pip install jpoke` でインストールしたライブラリ利用者向けに、よく使う公開APIをまとめたもの。
+内部実装（`data/`, `handlers/`, 各種 `*_manager.py` など）の詳細は
+[CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/CLAUDE.md) を参照。
+
+外部からの利用（テスト・bot・探索コード）は `Battle` の公開メソッドを入口にする方針
+（[CLAUDE.md#開発ルール](https://github.com/tmwork1/jpoke/blob/main/CLAUDE.md)）のため、
+本リファレンスも `battle.<manager>.<method>()` のような内部マネージャーへの直接アクセスや、
+`_` 始まりの非公開属性は載せない。
+
+このドキュメントは **よく使う公開APIの見取り図**であり、全メソッド・全引数を網羅する
+ものではない。詳細な挙動・戻り値・例外条件は各クラスのdocstring（ソースコード:
+`src/jpoke/core/battle.py`, `src/jpoke/core/player.py`, `src/jpoke/model/pokemon.py`）を
+直接参照すること。
+
+対象範囲・アーキテクチャの全体像は [README.md](https://github.com/tmwork1/jpoke/blob/main/README.md)
+を参照。
+
+## 目次
+
+- [Battle](#battle)
+- [Player](#player)
+- [Pokemon](#pokemon)
+
+## Battle
+
+`src/jpoke/core/battle.py`。バトル全体の状態管理・ターン進行を担う中心クラス。
+
+### コンストラクタ
+
+```python
+Battle(
+    *players: Player,
+    n_selected: int | None = None,
+    seed: int | None = None,
+    mega_evolution: bool = True,
+    terastal: bool = True,
+    critical_mode: CriticalMode = "normal",       # "normal" / "always"
+    damage_roll: DamageRollMode = "normal",        # "normal" / "average" / "max" / "min"
+    accuracy_fix_threshold: int | None = None,
+    effect_chance_threshold: float | None = None,
+    double_battle: bool = False,
+)
+```
+
+- `*players`: 参加プレイヤー（可変長引数、通常2人）。`Battle(player1, player2)` のように
+  個別の位置引数で渡す（タプル渡しは不可）
+- `n_selected`: 選出可能なポケモンの数。省略時は `min(3, 各プレイヤーの手持ち数)` が自動設定される
+- `seed`: 乱数シード値。省略時はOSの乱数源から高エントロピーな値を生成する
+- `mega_evolution` / `terastal`: メガシンカ／テラスタルを許可するか（デフォルト両方 `True`）
+- `critical_mode`: 急所判定モード（デフォルト `"normal"`）
+- `damage_roll`: ダメージ乱数モード（デフォルト `"normal"`）
+- `accuracy_fix_threshold`: この値以上の命中率を100%固定にする（`None` なら無効）
+- `effect_chance_threshold`: この値未満の追加効果確率を0%にする（`None` なら無効）
+- `double_battle`: ダブルバトル向けのダメージ計算補正を有効にするか（デフォルト `False`。
+  **対戦進行自体はシングルバトル専用**であることに変わりはない）
+
+```python
+from jpoke import Battle, Player
+
+player1 = Player("Player 1")
+player1.add_pokemon("ピカチュウ", move_names=["でんこうせっか"])
+player2 = Player("Player 2")
+player2.add_pokemon("フシギダネ", move_names=["たいあたり"])
+
+battle = Battle(player1, player2, seed=1, damage_roll="max", critical_mode="always")
+battle.start()
+```
+
+### 対戦進行系
+
+| API | 概要 |
+|---|---|
+| `start()` | 選出と初期繰り出しを完了し、以降の `step()` を可能にする |
+| `step(commands=None)` | ターンを1つ進める。`commands` を省略すると各 `Player.choose_command()` に従う |
+| `play_out(max_turns=100)` | 決着がつくかターン上限に達するまで `step()` を自動的に繰り返す。勝者（`Player`）を返し、ターン上限で決着しなければ `None` |
+| `finished` (property) | poke-env互換。対戦が終了しているか |
+| `winner` (attribute) | 勝者の `Player`（未決着なら `None`）。`judge_winner()` を一度も呼ばないと未更新のままな点に注意（`finished`/`play_out()` 経由なら自動更新される） |
+| `judge_winner()` | 勝者を判定する（未決着なら `None`） |
+| `turn` (attribute) | 現在のターン数 |
+
+```python
+while not battle.finished and battle.turn < 100:
+    battle.step()
+print(battle.winner.username if battle.winner else "決着つかず")
+```
+
+`play_out()` を使うと上記ループは次の1行にまとめられる:
+
+```python
+winner = battle.play_out(max_turns=100)
+```
+
+### 状態取得系
+
+| API | 概要 |
+|---|---|
+| `get_active(player)` | 指定プレイヤーの現在場に出ているポケモンを取得（交代中などは `None`） |
+| `get_team(player)` | 指定プレイヤーの対戦中のチーム（選出漏れの控えも含む）を取得。`player.team` は開始前のスナップショットで対戦中は更新されないため、HP・瀕死・状態異常などバトル中の実際の状態を見るにはこちらを使う |
+| `get_available_commands(player)` | 現在使用可能な `Command` のリストを取得 |
+| `command_to_move(player, command)` | コマンドから `Move` オブジェクトを取得。`choose_command()` の実装で使う |
+
+```python
+active = battle.get_active(player1)
+team = battle.get_team(player1)  # 瀕死・HP変化などを反映した実体
+commands = battle.get_available_commands(player1)
+move = battle.command_to_move(player1, commands[0])
+```
+
+### ダメージ計算系
+
+| API | 概要 |
+|---|---|
+| `calc_lethal(attacker, moves, critical=False, secondary=False, max_attack=10)` | 指定した技（列）を最大 `max_attack` 回撃ち込んだ場合の致死率を計算する。`moves` には技名の文字列・`Move`・`(技, ヒット数)` のタプル、およびそれらのリストを渡せる。`list[LethalResult]` を返す（各要素が1ヒットに対応し、最終的な致死率は `results[-1].lethal_probability`） |
+| `calc_damages(attacker, defender, move, critical=False)` | 乱数によるダメージ幅を考慮した、可能な全ダメージ値のリスト（通常16通り）を返す |
+| `roll_damage(attacker, defender, move, critical=False)` | `calc_damages()` の結果から `option.damage_roll` に従って1つ選んで返す |
+
+```python
+results = battle.calc_lethal(attacker, moves="ドラゴンテール", max_attack=5)
+final = results[-1]
+print(f"{final.n_attack}回攻撃した時点の致死率: {final.lethal_probability:.2%}")
+
+raw_damages = battle.calc_damages(attacker, defender, "ドラゴンテール")
+one_damage = battle.roll_damage(attacker, defender, "ドラゴンテール")
+```
+
+### シナリオ構築系
+
+`Pokemon.hp` への直接代入や `boosts` の直接書き換えは禁止されている。状態を作るときは
+必ず以下の `Battle` 経由のメソッドを使う。
+
+| API | 概要 |
+|---|---|
+| `modify_hp(target, v=0, r=0, source=None, reason="")` | HPを変更する。`v`（固定量）と `r`（最大HPに対する割合、-1.0〜1.0）は同時指定不可 |
+| `faint(target, source=None, reason="")` | 対象を即座にひんしにする（`modify_hp(v=-target.max_hp)` の薄いラッパー） |
+| `modify_stats(target, stats, source=None, reason="")` | 複数の能力ランクを同時に変更する |
+| `set_ailment(target, name, count=None)` | 状態異常を直接付与する（特性・タイプによる無効化判定はしない、シナリオ構築用の薄いラッパー） |
+| `set_weather(name, count=5)` | 天候を直接発動する |
+| `set_terrain(name, count=5)` | 地形を直接発動する |
+
+```python
+battle.modify_hp(defender, r=-0.6, reason="シナリオ構築用")   # 最大HPの60%分ダメージ
+battle.modify_stats(defender, {"def": 1})                    # ぼうぎょ+1
+battle.set_ailment(defender, "どく")
+battle.faint(defender)
+```
+
+### ログ系
+
+| API | 概要 |
+|---|---|
+| `print_logs(turn=None)` | 指定ターンのログを整形して出力する。`turn="all"` で1ターン目から現在までの全ログ |
+| `get_log_lines(turn=None)` | `print_logs()` と同じ内容を文字列のリストとして返す（出力先を呼び出し側に委ねたい場合） |
+| `get_event_logs(turn=None)` | `LogCode` 付きの構造化ログ（`EventLog`）を `Player` をキーとする辞書で返す。特定の種類のイベント（急所発生など）だけをプログラムで抽出したいときに使う |
+
+```python
+battle.print_logs()  # 現在ターンのログを表示
+
+from jpoke.enums import LogCode
+critical_hits = [
+    log.pokemon
+    for logs in battle.get_event_logs().values()
+    for log in logs
+    if log.log is LogCode.CRITICAL_HIT
+]
+```
+
+### poke-env互換プロパティ
+
+`observer`（プレイヤー視点）が設定されている前提のプロパティ群。方策実装（`choose_command()`）に
+渡される `battle` は観測用コピーで、`battle.observer` が呼び出し元プレイヤー自身に設定されている。
+
+| API | 概要 |
+|---|---|
+| `active_pokemon` | observer視点の場のポケモン |
+| `opponent_active_pokemon` | observerから見た相手側の場のポケモン |
+| `available_moves` | observerが選択可能な技（`Move`）のリスト |
+| `available_switches` | observerが交代可能なポケモンのリスト |
+| `side_conditions` | observer側のサイドフィールド状態の辞書 |
+| `team` | observer側のチーム（`list[Pokemon]`。poke-envは`Dict[str, Pokemon]`だが差異あり） |
+| `finished` / `won(player)` / `lost(player)` | 対戦終了判定・勝敗判定 |
+
+```python
+class MyPlayer(Player):
+    def choose_command(self, battle: Battle) -> Command:
+        moves = battle.available_moves
+        if not moves:
+            return battle.get_available_commands(self)[0]
+        # battle.active_pokemon / battle.opponent_active_pokemon なども
+        # 自分視点の情報としてそのまま使える
+        ...
+```
+
+### リプレイ系
+
+| API | 概要 |
+|---|---|
+| `build_replay_data()` | 対戦を再現するためのリプレイデータ（`BattleReplayData`）を組み立てる。対戦の途中でも呼べる |
+
+```python
+from jpoke.core.replay import replay_battle
+
+replay_data = battle.build_replay_data()
+serialized = replay_data.to_dict()          # json.dumps() 可能な辞書へ
+restored = type(replay_data).from_dict(serialized)
+replayed_battle = replay_battle(restored)   # 同じ展開の対戦を再生
+```
+
+## Player
+
+`src/jpoke/core/player.py`。バトルに参加するプレイヤー（人間・AI方策どちらの土台にもなる）。
+
+```python
+Player(username: str = "")
+```
+
+### `add_pokemon()`
+
+```python
+add_pokemon(
+    name: PokemonName,
+    gender: Gender = "",
+    nature: Nature = "まじめ",
+    level: int = 50,
+    ability_name: AbilityName = "",
+    item_name: ItemName = "",
+    move_names: list[MoveName] | None = None,
+    tera_type: Type | None = None,
+) -> Pokemon
+```
+
+ポケモンを1体作成し `team` に追加する。`from jpoke import Pokemon` を使わずにチームを
+組める正規の追加ルート。引数はそのまま `Pokemon.__init__` に渡される。戻り値の `Pokemon`
+は交代先の参照などに使える。
+
+```python
+from jpoke import Player
+
+player = Player("Player 1")
+attacker = player.add_pokemon(
+    "ガブリアス", nature="いじっぱり", ability_name="さめはだ",
+    item_name="こだわりスカーフ", move_names=["じしん", "げきりん"],
+)
+```
+
+### `team` 属性の注意点
+
+`player.team` は **コンストラクタ〜対戦開始前のスナップショット**であり、`Battle` 開始後の
+対戦中はここに反映されるHP・瀕死・状態異常・ランク変化などは更新されない。対戦中の実際の
+状態を見たい場合は `battle.get_active(player)`（場に出ているポケモン）や
+`battle.get_team(player)`（チーム全体の実体）を使う。
+
+### `choose_command()` のオーバーライド
+
+方策（AI）を実装するには `Player` を継承し `choose_command()` をオーバーライドする。
+デフォルト実装は「利用可能な行動コマンドの最初の1つを返す」だけの決定的な実装。
+
+```python
+from jpoke import Battle, Player
+from jpoke.enums import Command
+
+class StrongestMovePlayer(Player):
+    """毎ターン、利用可能な技の中から最も威力の高い技を選ぶプレイヤー。"""
+
+    def choose_command(self, battle: Battle) -> Command:
+        commands = battle.get_available_commands(self)
+
+        def move_power(command: Command) -> int:
+            if not command.is_regular_move:
+                return -1
+            move = battle.command_to_move(self, command)
+            return move.base_power if move.is_attack else 0
+
+        return max(commands, key=move_power)
+```
+
+選出番号を決める `choose_selection(battle)`（デフォルトは先頭から順に選出）も同様の要領で
+オーバーライドできる。
+
+### `battle_against()`
+
+poke-env互換: 各対戦相手と `n_battles` 回ずつ対戦し、双方の戦績（`n_finished_battles` /
+`n_won_battles` など）を更新する。ネットワークI/Oがないため同期メソッド。
+
+```python
+player1.battle_against(player2, n_battles=100, seed=1)
+print(f"{player1.username} 勝率: {player1.win_rate:.1%}")
+```
+
+## Pokemon
+
+`src/jpoke/model/pokemon.py`。ポケモン1体の全状態（種族値・技・特性・アイテム・状態異常など）を
+管理するクラス。
+
+### コンストラクタ
+
+```python
+Pokemon(
+    name: PokemonName,
+    gender: Gender = "",
+    nature: Nature = "まじめ",           # デフォルトはステータス補正なし
+    level: int = 50,
+    ability_name: AbilityName = "",     # 省略時は特性なし扱い
+    item_name: ItemName = "",           # 省略時はアイテムなし
+    move_names: list[MoveName] | None = None,  # 省略時は["はねる"]の1技のみ
+    tera_type: Type | None = None,      # 省略時はそのポケモンの第1タイプを引き継ぐ
+)
+```
+
+個体値・努力値はコンストラクタの引数ではなく、初期状態は**個体値31・努力値0固定**で
+生成される。変更する場合は生成後に `set_ivs()` / `set_evs()` を呼ぶ。
+
+```python
+from jpoke import Pokemon
+
+mon = Pokemon(
+    "ガブリアス", nature="いじっぱり", ability_name="さめはだ",
+    item_name="こだわりスカーフ", move_names=["じしん", "げきりん"],
+)
+mon.set_evs([0, 32, 0, 0, 0, 0])   # こうげき努力値をChampions形式（0〜32）で最大まで振る
+mon.set_ivs([31, 31, 31, 31, 31, 0])
+```
+
+### `set_evs()` / `set_ivs()`
+
+- `set_evs(evs, hp_policy="keep_absolute")`: 努力値を**Champions形式（各値0〜32）**で設定する。
+  poke-envの努力値（各値0〜252）とはスケールが異なるため、poke-env形式の値をそのまま渡さない
+  こと（`types/poke_env.py` の `evs_from_poke_env` で変換する）
+- `set_ivs(ivs, hp_policy="keep_absolute")`: 個体値を設定する
+- どちらも設定後にステータスを自動再計算する。`hp_policy` は最大HPが変化したときの現在HPの
+  追従方法を指定する引数（`Pokemon.set_level` など他のステータス変更系メソッドにも共通）
+
+### `show()`
+
+```python
+mon.show()   # 実数値・性格・特性・持ち物・テラスタイプ・技構成をまとめて表示
+```
+
+出力先を選びたい場合は `render_info()`（文字列を返すだけで `print` しない）を使う。
+
+### 状態読み取り系
+
+| API | 概要 |
+|---|---|
+| `status` (property) | poke-env互換。状態異常名（`ailment.name` のエイリアス） |
+| `has_ailment(*ailment_names)` | 指定した状態異常のいずれかを持っているか |
+| `has_volatile(volatile_name)` | 指定した揮発性状態を持っているか |
+| `fainted` (property) | HPが0（ひんし）かどうか |
+| `alive` (property) | HPが0より大きいかどうか |
+| `hp` / `max_hp` / `hp_fraction` | 現在HP／最大HP／HP割合 |
+| `has_item(name=None, consider_enabled=False)` | アイテムを持っているか |
+| `has_move(move)` | 指定した技を持っているか |
+
+```python
+print(mon.status, mon.has_ailment("どく"), mon.has_volatile("こんらん"))
+print(mon.fainted, mon.hp, mon.max_hp)
+```
+
+## 関連リンク
+
+- [README.md](https://github.com/tmwork1/jpoke/blob/main/README.md) — クイックスタート・
+  アーキテクチャ概要・対象範囲の定義
+- [examples/](https://github.com/tmwork1/jpoke/blob/main/examples/README.md) — 導入・AI開発・
+  ダメージ計算ツール開発・戦術研究のユースケース別サンプルスクリプト
+- `tests/CLAUDE.md` — clone前提のテストヘルパー（`start_battle` / `run_move` 等）の使い方

--- a/docs/plan/pypi_release.md
+++ b/docs/plan/pypi_release.md
@@ -202,8 +202,14 @@ package-check:
 
 ## フェーズ 4: 公開後の改善（ブロッカーではない）
 
-- 利用者向け API リファレンスの整備（`docs/` は現状すべて開発内部向け。
-  最低限 `Battle` / `Player` / `Pokemon` の公開 API を README か `docs/api/` にまとめる）
+- 実施済み: 利用者向け API リファレンスの整備。`docs/api/README.md` を新設し、
+  `Battle`（コンストラクタ主要引数・対戦進行系/状態取得系/ダメージ計算系/シナリオ構築系/
+  ログ系/poke-env互換プロパティ/リプレイ系にグルーピング）、`Player`（`add_pokemon()`,
+  `choose_command()` のオーバーライド方法, `team` 属性がスナップショットである注意点,
+  `battle_against()`）、`Pokemon`（コンストラクタ引数のデフォルト値, `set_evs()`/`set_ivs()`,
+  `show()`, 状態読み取り系）を実際のソースコード（`core/battle.py`, `core/player.py`,
+  `model/pokemon.py`）を読んで確認しながらまとめた。README.md の「ドキュメント」テーブルにも
+  1行追加
 - `tests/test_utils.py` の主要ヘルパー（`start_battle` / `run_move` / `run_switch`）を
   `jpoke.testing` として本体パッケージへ昇格
 - 実施済み: `core` ⇔ `model` ⇔ `data` の循環 import 解消。パッケージ内の他ファイルが


### PR DESCRIPTION
## Summary
- PyPI公開後改善タスク（`docs/plan/pypi_release.md` フェーズ4）の「利用者向けAPIリファレンスの整備」に対応
- `docs/api/README.md` を新設し、`Battle`/`Player`/`Pokemon` の公開APIを機能別（対戦進行・状態取得・ダメージ計算・シナリオ構築・ログ・poke-env互換・リプレイ等）にまとめた
- 記載した全メソッド名・引数名・デフォルト値は実際のソースコード（`src/jpoke/core/battle.py`等）を読んで裏取り済み
- README.mdの「ドキュメント」テーブルに導線を追加

## Test plan
- [x] `python -m pytest tests/ -q` 4842 passed, 1 skipped（コード変更なし）
- [x] `python -m ruff check .` All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)