### PR TITLE
feat: tests/test_utils.py の主要ヘルパーを jpoke.testing として本体パッケージへ昇格

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@
   検証で、対戦を進行させずに状態異常・天候込みの複合致死率を確認できる
 - `examples/07_replay.py` — `Battle.build_replay_data()` / `ReplayPlayer` /
   `replay_battle()`（リプレイの記録・再生一式）を紹介するサンプルを新設
+- `jpoke.testing` モジュール — `tests/test_utils.py` にあった内部テストヘルパー
+  （`start_battle` / `run_move` / `run_switch` / `apply_ailment` /
+  `get_action_order` / `calc_lethal` / `fix_damage` / `fix_random` 等14関数と
+  `CustomPlayer`）を本体パッケージへ昇格。`pip install jpoke` だけで（リポジトリを
+  clone せずに）任意ターンでのピンポイントな状態検証・技の実行ができるようになった。
+  `tests/test_utils.py` は後方互換のための薄い再エクスポート層として残している。
+  移植にあたり `Battle` に不足していた公開ラッパーを追加した:
+  `Battle.set_ailment()` に `source` / `overwrite` 引数を追加、
+  `Battle.set_volatile()` / `Battle.set_item()` /
+  `Battle.activate_global_field()` / `Battle.activate_side_field()` /
+  `Battle.resolve_action_order()` / `Battle.calc_move_priority()` /
+  `Battle.can_switch()` / `Battle.end_turn()` を新設
+  （いずれも `ailment_manager` 等の内部マネージャーへの薄い委譲で、外部コードが
+  `battle.<manager>.<method>()` を直接呼ばずに済むようにするための追加）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ battle.print_logs()                 # このターンのログを表示
 開発への貢献方法は [CONTRIBUTING.md](https://github.com/tmwork1/jpoke/blob/main/CONTRIBUTING.md)、
 脆弱性の報告方法は [SECURITY.md](https://github.com/tmwork1/jpoke/blob/main/SECURITY.md) を参照。
 
+`jpoke.testing` — `pip install jpoke` だけで使える、任意ターンでのピンポイントな状態検証・技の
+実行などを行うテストヘルパー集（`start_battle` / `run_move` / `run_switch` 等）。詳細は後述の
+「テストヘルパーを使った検証」を参照。
+
 ## 実装状況
 
 `docs/progress/*.md` に基づく件数（データ定義済みの実数、内部用の空エントリ等を除く）:
@@ -117,10 +121,34 @@ battle.print_logs()                 # このターンのログを表示
 
 最新の詳細は `docs/progress/` 配下の各ファイルを参照。
 
+## テストヘルパーを使った検証
+
+任意ターンでのピンポイントな状態検証や技の実行など、クイックスタートより細かい制御をしたい場合は
+`jpoke.testing` のヘルパー（`start_battle` / `run_move` / `run_switch` 等）が便利。
+`pip install jpoke` だけで（リポジトリを clone せずに）使える:
+
+```python
+from jpoke import Pokemon
+from jpoke import testing as t
+
+battle = t.start_battle(
+    team0=[Pokemon("ピカチュウ", ability_name="せいでんき", move_names=["でんこうせっか"])],
+    team1=[Pokemon("カビゴン", move_names=["たいあたり"])],
+    accuracy=100,  # 命中率を固定して再現性を上げる
+)
+t.run_move(battle, atk_idx=0, move_idx=0)
+```
+
+`fix_damage` / `fix_random` は対戦オブジェクトの内部属性を直接差し替えるモンキーパッチのため、
+テスト・デバッグ専用であり本番の対戦進行では使わないこと。
+
+リポジトリ内部のテストコード（`tests/`）は同じ実体を `tests/test_utils.py` 経由（後方互換の
+薄い再エクスポート層）で使っている。詳細な使い方は
+[tests/CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/tests/CLAUDE.md) も参照。
+
 ## 開発（clone 前提）
 
-ソースを直接編集する場合や、テストヘルパーを使ってピンポイントな状態検証をしたい場合は
-リポジトリを clone してセットアップする。
+ソースを直接編集する場合はリポジトリを clone してセットアップする。
 
 ```bash
 git clone https://github.com/tmwork1/jpoke.git
@@ -131,27 +159,6 @@ pip install -e .
 pip install -e . pytest pytest-cov ruff mypy
 # または uv を使う場合
 uv sync
-```
-
-### テストヘルパーを使った検証
-
-任意ターンでのピンポイントな状態検証や技の実行など、クイックスタートより細かい制御をしたい場合は
-`tests/test_utils.py` のヘルパー（`start_battle` / `run_move` / `run_switch` 等）が便利。
-これはテスト用のヘルパーだが、プロジェクトルートから実行すれば（`tests/` が import できる状態）
-通常のスクリプトからも使える。詳細な使い方は
-[tests/CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/tests/CLAUDE.md) を参照:
-
-```python
-# プロジェクトルートから実行する想定（tests/ が import できる状態）
-from jpoke import Pokemon
-from tests import test_utils as t
-
-battle = t.start_battle(
-    team0=[Pokemon("ピカチュウ", ability_name="せいでんき", move_names=["でんこうせっか"])],
-    team1=[Pokemon("カビゴン", move_names=["たいあたり"])],
-    accuracy=100,  # 命中率を固定して再現性を上げる
-)
-t.run_move(battle, atk_idx=0, move_idx=0)
 ```
 
 ## テストの実行

--- a/docs/plan/pypi_release.md
+++ b/docs/plan/pypi_release.md
@@ -214,8 +214,61 @@ package-check:
   `show()`, 状態読み取り系）を実際のソースコード（`core/battle.py`, `core/player.py`,
   `model/pokemon.py`）を読んで確認しながらまとめた。README.md の「ドキュメント」テーブルにも
   1行追加
-- `tests/test_utils.py` の主要ヘルパー（`start_battle` / `run_move` / `run_switch`）を
-  `jpoke.testing` として本体パッケージへ昇格
+- 実施済み: `tests/test_utils.py` の14関数（`start_battle` / `run_move` / `run_switch` /
+  `end_turn` / `apply_ailment` / `fix_damage` / `fix_random` / `get_action_order` /
+  `change_item` / `calc_lethal` / `calc_move_priority` / `build_context` /
+  `reserve_command` / `can_switch`）と `CustomPlayer` を `src/jpoke/testing.py` として
+  本体パッケージへ昇格（`pyproject.toml` は無変更で反映確認済み。`packages.find` が
+  `jpoke` パッケージ配下のモジュールを自動的に含めるため、`python -m build` →
+  クリーンvenvへのwheelインストール → `import jpoke.testing` の実地確認で
+  追加設定不要と判断）。`tests/test_utils.py` は既存テストの
+  `from . import test_utils as t` / `from .. import test_utils as t` という参照パターンを
+  壊さないよう `jpoke.testing` を再エクスポートする薄いシムに変更した。
+  移植時に判明した「内部マネージャー直呼び」の難所は以下のように判断した:
+  - `apply_ailment`（`ailment_manager.apply` の `source`/`overwrite` 引数を使用）は、
+    既存の `Battle.set_ailment()` が常に上書き・`source` 指定不可だったため意味が
+    変わってしまうと判断し、`Battle.set_ailment()` 自体に `source` / `overwrite`
+    引数を追加（デフォルト値は `overwrite=True` のまま据え置き、既存呼び出し元との
+    後方互換を維持）して吸収した
+  - `get_action_order`（`speed_calculator.resolve_action_order()` 直呼び）と
+    `calc_move_priority`（`speed_calculator.calc_move_priority()` 直呼び）は、
+    既に `Battle.resolve_speed_order()` という同種の薄い委譲メソッドが前例として
+    存在したため、同じパターンで `Battle.resolve_action_order()` /
+    `Battle.calc_move_priority()` を新設して公開APIに昇格した
+  - `change_item`（`item_manager.gain_item`/`remove_item`/`can_change_item` に加えて
+    private な `_change_item` を直接呼んでいた）は、「持ち物を持っている状態から
+    別の持ち物へ直接差し替える」経路を表す public メソッドが `ItemManager` に
+    存在しなかったため、`ItemManager.set_item()` を新設（`_change_item` の呼び出しは
+    同クラス内に閉じたので privateアクセスの問題も解消）し、`Battle.set_item()` で
+    公開した
+  - `can_switch`（`query.can_switch()` 直呼び）も同様に `Battle.can_switch()` を
+    新設して公開した。`PokemonQuery` の他のメソッド（`is_floating` 等）は
+    ハンドラ内部専用の判定ロジックであり外部から使う想定がないため、今回は
+    `can_switch` 以外への公開ラッパー追加は見送った
+  - `start_battle` が使っていた `volatile_manager.apply` / `global_manager.activate` /
+    `side_managers[i].activate` にも同様の理由で
+    `Battle.set_volatile()` / `Battle.activate_global_field()` /
+    `Battle.activate_side_field()` を新設し、`set_ailment`/`set_weather`/`set_terrain`
+    と並ぶ「シナリオ構築・ダメージ計算検証用」薄いラッパー群として揃えた
+  - `end_turn`（`events.emit(Event.ON_TURN_END)` 直呼び）も `Battle.end_turn()` を
+    新設して公開した。ターン終了時効果だけを技の実行なしに検証したい場合の
+    ショートカットである旨をdocstringに明記した
+  - `fix_damage` / `fix_random` は `Battle.roll_damage` / `Battle.random.random` を
+    差し替えるモンキーパッチであり、公開APIとして安定化させる性質のものではないと
+    判断。`jpoke.testing` に残しつつ、docstringに「テスト・デバッグ専用、本番の対戦
+    進行では使わないこと」と明記するに留めた（`fix_random` は `random()` のみを
+    固定し `choice`/`randint`/`shuffle` には効かない注意点も明記）
+  - `reserve_command`（`battle.phase_context()` と `player_states[player]` から得た
+    `PlayerState` の `reset_turn_state()`/`reserve_command()` を呼ぶ）は、通常の対戦
+    進行が `step()` を介するのに対し、コマンド予約状態だけを対戦を進めずに作る
+    シナリオ検証専用の操作であり、`step()` に代わる安定した公開APIとして一般化する
+    のは時期尚早と判断し、`player_states`（既存の公開プロパティ）経由のアクセスを
+    そのまま維持した。docstringにその旨と用途を明記した
+  - 検証: `python -m pytest tests/ -q`（4842 passed, 1 skipped）、
+    `python -m pytest tests/test_examples_smoke.py -q`、`python -m ruff check src/ tests/`、
+    `python -m mypy` がいずれも成功。`python -m build` でwheelを作成し、クリーンな
+    venvに実際にインストールして `import jpoke.testing` と `start_battle`/`run_move`/
+    `get_action_order` の実行まで通ることを確認済み
 - 実施済み: `core` ⇔ `model` ⇔ `data` の循環 import 解消。パッケージ内の他ファイルが
   `from jpoke.core import X` / `from jpoke.model import X` / `from jpoke.data import X` という
   パッケージレベル絶対importを使い、対象パッケージの `__init__.py` が完全実行済みであることに

--- a/src/jpoke/core/battle.py
+++ b/src/jpoke/core/battle.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 
 from jpoke.types import BattlePhase, Stat, StatChangeReason, GlobalFieldName, \
     HPChangeReason, AbilityDisabledReason, AbilityName, MoveName, CriticalMode, DamageRollMode, \
-    AilmentName, WeatherName, TerrainName
+    AilmentName, WeatherName, TerrainName, VolatileName, SideFieldName, ItemName
 from jpoke.enums import Event, Command, LogCode
 from jpoke.exceptions import InvalidCommandError, InvalidPhaseError
 from jpoke.utils import fast_copy
@@ -577,6 +577,19 @@ class Battle:
 
         raise InvalidPhaseError(f"Invalid phase: {self.phase}")
 
+    def can_switch(self, player: Player) -> bool:
+        """指定したプレイヤーが交代可能かどうかを判定する（PokemonQueryへの委譲）。
+
+        場のポケモンがとらわれ状態にある場合、または控えが全滅している場合はFalse。
+
+        Args:
+            player: 判定するプレイヤー
+
+        Returns:
+            bool: 交代可能な場合True
+        """
+        return self.query.can_switch(player)
+
     def resolve_speed_order(self) -> list[Pokemon]:
         """素早さ順序を解決（SpeedCalculatorへの委譲）。
 
@@ -584,6 +597,33 @@ class Battle:
             素早さの速い順にソートされたポケモンのリスト
         """
         return self.speed_calculator.resolve_speed_order()
+
+    def resolve_action_order(self) -> list[Pokemon]:
+        """技の行動順序を解決する（SpeedCalculatorへの委譲）。
+
+        優先度と実効素早さを考慮した行動順を返す。各プレイヤーに予約済みコマンド
+        （`player_states[player].reserved_commands`）が必要（`step()` 内部や
+        シナリオ検証で `phase_context` 経由でコマンドを予約した後に呼ぶ）。
+
+        Returns:
+            list[Pokemon]: 行動順にソートされたポケモンのリスト
+        """
+        return self.speed_calculator.resolve_action_order()
+
+    def calc_move_priority(self, attacker: Pokemon, move: Move) -> int:
+        """技を発動したときの優先度を計算する（SpeedCalculatorへの委譲）。
+
+        技本来の優先度に加え、ON_MODIFY_MOVE_PRIORITYイベント（さきどり等）による
+        補正後の優先度を返す。
+
+        Args:
+            attacker: 技を使用するポケモン
+            move: 使用する技
+
+        Returns:
+            int: 補正後の優先度
+        """
+        return self.speed_calculator.calc_move_priority(attacker, move)
 
     def judge_winner(self) -> Player | None:
         """勝者を判定（TurnControllerへの委譲）。
@@ -749,21 +789,48 @@ class Battle:
         """ポケモンの複数の能力ランクを同時に変更する（StatusManagerへの委譲）。"""
         return self.status_manager.modify_stats(target, stats, source=source, reason=reason)
 
-    def set_ailment(self, target: Pokemon, name: AilmentName, count: int | None = None) -> bool:
+    def set_ailment(self,
+                    target: Pokemon,
+                    name: AilmentName,
+                    count: int | None = None,
+                    source: Pokemon | None = None,
+                    overwrite: bool = True) -> bool:
         """状態異常を直接付与する（シナリオ構築・ダメージ計算検証用）。
 
-        既存の状態異常があれば上書きする。特性・タイプ等による無効化判定は行わない
+        既定では既存の状態異常があれば上書きする。特性・タイプ等による無効化判定は行わない
         （examples/スクリプトから素直に状態を作るための薄いラッパーのため）。
 
         Args:
             target: 対象のポケモン
             name: 状態異常名
             count: 継続ターン数（ねむりは省略時にChampions仕様で自動決定）
+            source: 状態異常の原因となったポケモン（シンクロ等、原因ポケモンを
+                参照するハンドラの検証に使う）
+            overwrite: False の場合、既に状態異常があれば付与に失敗する
+                （デフォルトTrueで既存の状態異常を上書き）
 
         Returns:
             bool: 付与に成功した場合True
         """
-        return self.ailment_manager.apply(target, name, count=count, overwrite=True)
+        return self.ailment_manager.apply(target, name, count=count, source=source, overwrite=overwrite)
+
+    def set_volatile(self,
+                     target: Pokemon,
+                     name: VolatileName,
+                     count: int | None = None,
+                     source: Pokemon | None = None) -> bool:
+        """揮発性状態を直接付与する（シナリオ構築・ダメージ計算検証用）。
+
+        Args:
+            target: 対象のポケモン
+            name: 揮発性状態名
+            count: 継続ターン数
+            source: 揮発性状態の原因となったポケモン
+
+        Returns:
+            bool: 付与に成功した場合True（既に同じ揮発性状態がある場合は失敗）
+        """
+        return self.volatile_manager.apply(target, name, count=count, source=source)
 
     def set_weather(self, name: WeatherName, count: int = 5) -> bool:
         """天候を直接発動する（シナリオ構築・ダメージ計算検証用）。
@@ -788,6 +855,44 @@ class Battle:
             bool: 発動に成功した場合True
         """
         return self.terrain_manager.apply(name, count)
+
+    def activate_global_field(self, name: GlobalFieldName, count: int) -> bool:
+        """グローバルフィールド効果を直接発動する（シナリオ構築・ダメージ計算検証用）。
+
+        Args:
+            name: グローバルフィールド効果名
+            count: 持続ターン数
+
+        Returns:
+            bool: 発動に成功した場合True
+        """
+        return self.global_manager.activate(name, count)
+
+    def activate_side_field(self, player: Player, name: SideFieldName, count: int) -> bool:
+        """指定プレイヤーのサイドフィールド効果を直接発動する（シナリオ構築・ダメージ計算検証用）。
+
+        Args:
+            player: 発動対象のサイドを持つプレイヤー
+            name: サイドフィールド効果名
+            count: 層数・持続ターン数（効果による）
+
+        Returns:
+            bool: 発動に成功した場合True
+        """
+        return self.get_side(player).activate(name, count)
+
+    def set_item(self, target: Pokemon, name: ItemName, source: Pokemon | None = None) -> bool:
+        """ポケモンの持ち物を直接設定する（シナリオ構築・ダメージ計算検証用）。
+
+        Args:
+            target: 持ち物を設定するポケモン
+            name: 設定後の持ち物名（空文字列の場合は持ち物を外す）
+            source: 変更の原因となったポケモン（例: 交換元のポケモン、技の使用者など）
+
+        Returns:
+            bool: 設定に成功した場合True
+        """
+        return self.item_manager.set_item(target, name, source=source)
 
     def roll_damage(self,
                     attacker: Pokemon,
@@ -872,6 +977,16 @@ class Battle:
             emit: ON_SWITCH_INイベントを発火する場合True
         """
         self.switch_manager.run_switch(player, new, emit)
+
+    def end_turn(self) -> None:
+        """ターン終了処理（ON_TURN_ENDイベント）のみを発火する（シナリオ構築・検証用）。
+
+        通常のターン進行は `step()` が内部でこのイベントも含めて実行するため、
+        対戦を進めながら使う分にはこのメソッドは不要。技を使わず状態異常・天候・
+        揮発性状態などのターン終了時効果（毒ダメージ・やけど回復阻害・天候ダメージ等）
+        だけを単体で検証したい場合に使う。
+        """
+        self.events.emit(Event.ON_TURN_END)
 
     def add_event_log(self,
                       source: Player | Pokemon | int,

--- a/src/jpoke/core/item_manager.py
+++ b/src/jpoke/core/item_manager.py
@@ -208,6 +208,37 @@ class ItemManager:
         self._change_item(target, "", track_loss=track_loss)
         return True
 
+    def set_item(self,
+                target: Pokemon,
+                name: ItemName,
+                source: Pokemon | None = None) -> bool:
+        """ポケモンの持ち物を任意の状態に設定する（シナリオ構築・ダメージ計算検証用）。
+
+        現在の持ち物と一致する場合は何もせず成功扱いにする。持ち物を持たない場合は
+        そのまま獲得させ、name が空文字列の場合は除去する。既に別の持ち物を持っている
+        場合は can_change_item による判定を経て入れ替える（gain_item / remove_item /
+        _change_item の組み合わせでは表現できない「既存の持ち物を別の持ち物へ
+        直接差し替える」経路をまとめたもの）。
+
+        Args:
+            target: 持ち物を設定するポケモン
+            name: 設定後の持ち物名（空文字列の場合は持ち物を外す）
+            source: 変更の原因となったポケモン（例: 交換元のポケモン、技の使用者など）
+
+        Returns:
+            bool: 設定に成功した場合True
+        """
+        if target.has_item(name):
+            return True
+        if not target.has_item():
+            return self.gain_item(target, name)
+        if not name:
+            return self.remove_item(target, source=source)
+        if not self.can_change_item(target, source=source):
+            return False
+        self._change_item(target, name)
+        return True
+
     def swap_items(self, *, ignore_sticky_hold: bool = False) -> bool:
         """2体のアイテムを入れ替える。
 

--- a/src/jpoke/testing.py
+++ b/src/jpoke/testing.py
@@ -1,0 +1,390 @@
+"""バトルシナリオ構築・検証用のテストヘルパー集。
+
+`tests/test_utils.py` にあった内部テスト専用ヘルパーを本体パッケージへ昇格したもの。
+`pip install jpoke` だけで（`jpoke` リポジトリを clone せずに）任意ターンでの
+ピンポイントな状態検証・技の実行・行動順の確認などができる。
+
+外部から使う関数の多くは `Battle` / `Pokemon` の公開メソッドのみに依存している。
+ただし `fix_damage` / `fix_random` は対戦オブジェクトの内部属性を直接差し替える
+デバッグ用のモンキーパッチであり、本番の対戦進行（bot 運用等）では使わないこと。
+"""
+from jpoke.core import Battle, Player, AttackContext
+from jpoke.core.lethal import LethalResult
+from jpoke.model import Pokemon, Move
+from jpoke.types import AilmentName, VolatileName, WeatherName, TerrainName, GlobalFieldName, SideFieldName, \
+    CriticalMode, DamageRollMode, ItemName
+from jpoke.enums import Command
+
+__all__ = [
+    "CustomPlayer",
+    "start_battle",
+    "reserve_command",
+    "build_context",
+    "run_move",
+    "run_switch",
+    "can_switch",
+    "change_item",
+    "end_turn",
+    "apply_ailment",
+    "get_action_order",
+    "fix_damage",
+    "fix_random",
+    "calc_lethal",
+    "calc_move_priority",
+]
+
+
+class CustomPlayer(Player):
+    """テスト用のカスタムプレイヤークラス。
+
+    常に利用可能な最初のコマンドを選択します。
+    """
+
+    def choose_selection(self, battle: Battle) -> list[int]:
+        """選出コマンドを選択する。"""
+        n_team = len(self.team)
+        return list(range(n_team))
+
+    def choose_command(self, battle: Battle) -> Command:
+        """行動コマンドを選択する（常に最初の利用可能なコマンド）。"""
+        return battle.get_available_commands(self)[0]
+
+
+def start_battle(team0: list[Pokemon],
+                 team1: list[Pokemon],
+                 ailment0: tuple[AilmentName, int | None] | None = None,
+                 ailment1: tuple[AilmentName, int | None] | None = None,
+                 volatile0: dict[VolatileName, int] | None = None,
+                 volatile1: dict[VolatileName, int] | None = None,
+                 weather: tuple[WeatherName, int] | None = None,
+                 terrain: tuple[TerrainName, int] | None = None,
+                 field: dict[GlobalFieldName, int] | None = None,
+                 side0: dict[SideFieldName, int] | None = None,
+                 side1: dict[SideFieldName, int] | None = None,
+                 accuracy: int | None = None,
+                 secondary_chance: float | None = None,
+                 mega_evolution: bool = True,
+                 terastal: bool = True,
+                 critical_mode: CriticalMode = "normal",
+                 damage_roll: DamageRollMode = "normal",
+                 accuracy_fix_threshold: int | None = None,
+                 effect_chance_threshold: float | None = None,
+                 double_battle: bool = False) -> Battle:
+    """バトルを初期化し、指定された状態でセットアップする。
+
+    Args:
+        team0: 味方のポケモンリスト
+        team1: 相手のポケモンリスト
+        ailment0: 味方の状態異常のタプル(名前, カウント)（Noneの場合は状態異常なし）
+        ailment1: 相手の状態異常のタプル(名前, カウント)（Noneの場合は状態異常なし）
+        volatile0: 味方の揮発効果の辞書{名前: カウント}（Noneの場合は効果なし）
+        volatile1: 相手の揮発効果の辞書{名前: カウント}（Noneの場合は効果なし）
+        weather: 初期天候のタプル(天候名, カウント)（Noneの場合は天候なし）
+        terrain: 初期地形のタプル(地形名, カウント)（Noneの場合は地形なし）
+        side0: 味方のサイドに設置する場の効果の辞書{名前: レイヤー数}（Noneの場合は効果なし）
+        side1: 相手のサイドに設置する場の効果の辞書{名前: レイヤー数}（Noneの場合は効果なし）
+        field: グローバルフィールドに設置する場の効果の辞書{名前: カウント}（Noneの場合は効果なし）
+        accuracy: 固定命中率（Noneの場合は通常計算、デフォルト: None）
+        secondary_chance: 追加効果確率の固定値（1.0=必ず発動, 0.0=発動しない, Noneの場合は通常計算）
+        mega_evolution: メガシンカを許可するか（デフォルトTrue）
+        terastal: テラスタルを許可するか（デフォルトTrue）
+        critical_mode: 急所判定モード（"normal" / "always"、デフォルト"normal"）
+        damage_roll: ダメージ乱数モード（"normal" / "average" / "max" / "min"、デフォルト"normal"）
+        accuracy_fix_threshold: この値以上の命中率を100%固定にする（Noneなら無効）
+        effect_chance_threshold: この値未満の追加効果確率を0%にする（Noneなら無効）
+        double_battle: ダブルバトル向けのダメージ計算補正
+            （複数対象になり得る技のダメージ0.75倍・壁の軽減率2/3倍）を有効にするか（デフォルトFalse）
+
+    Returns:
+        Battle: セットアップ済みのBattleインスタンス
+    """
+    # プレイヤーとバトルのセットアップ
+    if not team0:
+        raise ValueError("ally must contain at least one Pokemon")
+    if not team1:
+        raise ValueError("foe must contain at least one Pokemon")
+
+    players = (CustomPlayer("Player 1"), CustomPlayer("Player 2"))
+    for player, mons in zip(players, [team0, team1]):
+        for mon in mons:
+            player.team.append(mon)
+
+    battle = Battle(
+        *players,
+        mega_evolution=mega_evolution,
+        terastal=terastal,
+        critical_mode=critical_mode,
+        damage_roll=damage_roll,
+        accuracy_fix_threshold=accuracy_fix_threshold,
+        effect_chance_threshold=effect_chance_threshold,
+        double_battle=double_battle,
+    )
+    battle.start()
+
+    # 状態異常の適用
+    if ailment0 or ailment1:
+        ailments = [ailment0, ailment1]
+        for idx, mon in enumerate(battle.actives):
+            if not ailments[idx]:
+                continue
+            name, count = ailments[idx]
+            battle.set_ailment(mon, name, count=count)
+
+    # 揮発効果の適用
+    if volatile0 or volatile1:
+        volatiles = [volatile0, volatile1]
+        for idx, mon in enumerate(battle.actives):
+            if not volatiles[idx]:
+                continue
+            for name, count in volatiles[idx].items():
+                battle.set_volatile(mon, name, count=count)
+
+    # 天候の有効化
+    if weather:
+        name, weather_count = weather
+        battle.set_weather(name, weather_count)
+
+    # 地形の有効化
+    if terrain:
+        name, terrain_count = terrain
+        battle.set_terrain(name, terrain_count)
+
+    # グローバルフィールドの有効化
+    if field:
+        for name, count in field.items():
+            battle.activate_global_field(name, count)
+
+    # サイドフィールドの有効化（初期ターン後に実行してポケモンへのダメージを回避）
+    if side0:
+        for name, layers in side0.items():
+            battle.activate_side_field(battle.players[0], name, layers)
+    if side1:
+        for name, layers in side1.items():
+            battle.activate_side_field(battle.players[1], name, layers)
+
+    # 命中率の設定
+    if accuracy is not None:
+        battle.test_option.accuracy = accuracy
+
+    # 追加効果確率の設定
+    if secondary_chance is not None:
+        battle.test_option.secondary_chance = secondary_chance
+
+    battle.print_logs()
+
+    return battle
+
+
+def reserve_command(battle: Battle,
+                    command0: Command | None = None,
+                    command1: Command | None = None):
+    """各プレイヤーがコマンドを予約した状態にする。
+
+    `step()` を介さずに行動順や優先度だけを検証したい場合など、対戦を実際に
+    進行させずにコマンド予約状態だけを作りたいシナリオ検証用のヘルパー。
+
+    Args:
+        battle: Battleインスタンス
+        command0: プレイヤー0に予約するコマンド（Noneの場合はプレイヤーが選択）
+        command1: プレイヤー1に予約するコマンド（Noneの場合はプレイヤーが選択）
+    """
+    commands = [command0, command1]
+    with battle.phase_context("action"):
+        for i, (player, state) in enumerate(battle.player_states.items()):
+            state.reset_turn_state()
+            command = commands[i]
+            if command is None:
+                command = player.choose_command(battle)
+            state.reserve_command(command)
+
+
+def build_context(battle: Battle, atk_idx: int, move_idx: int = 0) -> AttackContext:
+    """AttackContextを構築するヘルパー関数。"""
+    attacker = battle.actives[atk_idx]
+    defender = battle.foe(attacker)
+    move = attacker.moves[move_idx]
+    return AttackContext(attacker=attacker, defender=defender, move=move)
+
+
+def run_move(battle: Battle, atk_idx: int, move_idx: int = 0) -> Move:
+    """技を実行するヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        atk_idx: 技を使用するポケモンのインデックス
+        move_idx: 使用する技のインデックス（デフォルト: 0）
+
+    Returns:
+        使用した技のインスタンス
+    """
+    attacker = battle.actives[atk_idx]
+    move = attacker.moves[move_idx]
+    battle.run_move(attacker, move)
+    battle.print_logs()
+    return move
+
+
+def run_switch(battle: Battle, player_idx: int, new_idx: int) -> Pokemon:
+    """ポケモンを入れ替えるヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        player_idx: 入れ替えるプレイヤーのインデックス
+        new_idx: 入れ替えるポケモンのインデックス
+
+    Returns:
+        入れ替えたポケモンのインスタンス
+    """
+    player = battle.players[player_idx]
+    mon = battle.player_states[player].team[new_idx]
+    battle.run_switch(player, mon)
+    return mon
+
+
+def can_switch(battle: Battle, player_idx: int) -> bool:
+    """ポケモンを入れ替え可能か判定するヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        player_idx: 判定するプレイヤーのインデックス
+
+    Returns:
+        入れ替え可能かどうか
+    """
+    player = battle.players[player_idx]
+    return battle.can_switch(player)
+
+
+def change_item(battle: Battle,
+                mon: Pokemon,
+                item_name: ItemName,
+                source: Pokemon | None = None) -> bool:
+    """アイテムを変更する。
+
+    Args:
+        battle: Battleインスタンス
+        mon: アイテムを変更するポケモン
+        item_name: 変更後のアイテム名（空文字列の場合はアイテムを外す）
+        source: アイテムを変更する原因となったポケモン（例: 交換元のポケモン、技の使用者など）
+
+    Returns:
+        アイテムの変更が成功したかどうか
+    """
+    return battle.set_item(mon, item_name, source=source)
+
+
+def end_turn(battle: Battle):
+    """ターンを終了するヘルパー関数。"""
+    battle.end_turn()
+
+
+def apply_ailment(battle: Battle,
+                  active_index: int,
+                  ailment_name: AilmentName,
+                  count: int = 1,
+                  by_foe: bool = False,
+                  overwrite: bool = False) -> bool:
+    """状態異常を適用するヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        active_index: 状態異常を適用するポケモンのインデックス
+        ailment_name: 適用する状態異常の名前
+        count: 状態異常のカウント（デフォルト: 1）
+        by_foe: 相手によって状態異常が適用されたかどうか（デフォルト: False）
+        overwrite: 既存の状態異常を上書きするかどうか（デフォルト: False）
+
+    Returns:
+        状態異常の適用が成功したかどうか
+    """
+    mon = battle.actives[active_index]
+    source = battle.foe(mon) if by_foe else None
+    return battle.set_ailment(mon, ailment_name, count=count, source=source, overwrite=overwrite)
+
+
+def get_action_order(battle: Battle,
+                     command0: Command | None = None,
+                     command1: Command | None = None) -> list[Pokemon]:
+    """行動順を取得するヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        command0: プレイヤー0のコマンド（Noneの場合はプレイヤーが選択）
+        command1: プレイヤー1のコマンド（Noneの場合はプレイヤーが選択）
+
+    Returns:
+        行動順のポケモンのリスト
+    """
+    reserve_command(battle, command0, command1)
+    return battle.resolve_action_order()
+
+
+def fix_damage(battle: Battle, damage: int):
+    """ダメージ計算のダイスロールを固定値にする。
+
+    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
+    `Battle.roll_damage` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
+    ダメージ計算は全て固定値になる。
+
+    Args:
+        battle: Battleインスタンス
+        damage: 固定するダメージ値
+    """
+    battle.roll_damage = lambda *args, **kwargs: damage
+
+
+def fix_random(battle: Battle, value: float):
+    """乱数を固定する。
+
+    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
+    `Battle.random.random` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
+    `random()` 呼び出しは全て固定値になる（`choice`/`randint`/`shuffle`等の他のメソッドには
+    効果がない点に注意）。
+
+    Args:
+        battle: Battleインスタンス
+        value: 固定する乱数の値（0.0以上1.0未満）
+    """
+    battle.random.random = lambda: value
+
+
+def calc_lethal(battle: Battle,
+                atk_idx: int,
+                moves: Move | tuple[Move, int] | list[Move | tuple[Move, int]],
+                critical: bool = False,
+                secondary: bool = False,
+                max_attack: int = 10) -> list[LethalResult]:
+    """致死率計算を実行するヘルパー関数。
+
+    Args:
+        battle: Battleインスタンス
+        atk_idx: 攻撃側ポケモンのインデックス
+        moves: 技（単体 / (技, ヒット数) / リスト）
+        critical: 急所計算をするか（デフォルト: False）
+        secondary: 追加効果ハンドラを適用するか（デフォルト: False）
+        max_attack: 最大攻撃回数（デフォルト: 10）
+
+    Returns:
+        各ヒット後の LethalResult のリスト（確定数が出た時点で打ち切り）
+    """
+    attacker = battle.actives[atk_idx]
+    return battle.calc_lethal(
+        attacker=attacker, moves=moves, critical=critical,
+        secondary=secondary, max_attack=max_attack
+    )
+
+
+def calc_move_priority(battle: Battle, player_index: int, move_index: int = 0) -> int:
+    """技を発動したときの優先度を返す。
+
+    Args:
+        battle: Battleインスタンス
+        player_index: 技を使用するポケモンのインデックス
+        move_index: 使用する技のインデックス（デフォルト: 0）
+
+    Returns:
+        技の優先度
+    """
+    mon = battle.actives[player_index]
+    move = mon.moves[move_index]
+    return battle.calc_move_priority(mon, move)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,362 +1,42 @@
-from jpoke.core import Battle, Player, AttackContext
-from jpoke.core.lethal import LethalResult
-from jpoke.model import Pokemon, Move
-from jpoke.types import AilmentName, VolatileName, WeatherName, TerrainName, GlobalFieldName, SideFieldName, \
-    CriticalMode, DamageRollMode
-from jpoke.enums import Event, Command
-
-
-class CustomPlayer(Player):
-    """テスト用のカスタムプレイヤークラス。
-
-    常に利用可能な最初のコマンドを選択します。
-    """
-
-    def choose_selection(self, battle: Battle) -> list[int]:
-        """選出コマンドを選択する。"""
-        n_team = len(self.team)
-        return list(range(n_team))
-
-    def choose_command(self, battle: Battle) -> Command:
-        """行動コマンドを選択する（常に最初の利用可能なコマンド）。"""
-        return battle.get_available_commands(self)[0]
-
-
-def start_battle(team0: list[Pokemon],
-                 team1: list[Pokemon],
-                 ailment0: tuple[AilmentName, int | None] | None = None,
-                 ailment1: tuple[AilmentName, int | None] | None = None,
-                 volatile0: dict[VolatileName, int] | None = None,
-                 volatile1: dict[VolatileName, int] | None = None,
-                 weather: tuple[WeatherName, int] | None = None,
-                 terrain: tuple[TerrainName, int] | None = None,
-                 field: dict[GlobalFieldName, int] | None = None,
-                 side0: dict[SideFieldName, int] | None = None,
-                 side1: dict[SideFieldName, int] | None = None,
-                 accuracy: int | None = None,
-                 secondary_chance: float | None = None,
-                 mega_evolution: bool = True,
-                 terastal: bool = True,
-                 critical_mode: CriticalMode = "normal",
-                 damage_roll: DamageRollMode = "normal",
-                 accuracy_fix_threshold: int | None = None,
-                 effect_chance_threshold: float | None = None,
-                 double_battle: bool = False) -> Battle:
-    """バトルを初期化し、指定された状態でセットアップする。
-
-    Args:
-        team0: 味方のポケモンリスト
-        team1: 相手のポケモンリスト
-        ailment0: 味方の状態異常のタプル(名前, カウント)（Noneの場合は状態異常なし）
-        ailment1: 相手の状態異常のタプル(名前, カウント)（Noneの場合は状態異常なし）
-        volatile0: 味方の揮発効果の辞書{名前: カウント}（Noneの場合は効果なし）
-        volatile1: 相手の揮発効果の辞書{名前: カウント}（Noneの場合は効果なし）
-        weather: 初期天候のタプル(天候名, カウント)（Noneの場合は天候なし）
-        terrain: 初期地形のタプル(地形名, カウント)（Noneの場合は地形なし）
-        side0: 味方のサイドに設置する場の効果の辞書{名前: レイヤー数}（Noneの場合は効果なし）
-        side1: 相手のサイドに設置する場の効果の辞書{名前: レイヤー数}（Noneの場合は効果なし）
-        field: グローバルフィールドに設置する場の効果の辞書{名前: カウント}（Noneの場合は効果なし）
-        accuracy: 固定命中率（Noneの場合は通常計算、デフォルト: None）
-        secondary_chance: 追加効果確率の固定値（1.0=必ず発動, 0.0=発動しない, Noneの場合は通常計算）
-        mega_evolution: メガシンカを許可するか（デフォルトTrue）
-        terastal: テラスタルを許可するか（デフォルトTrue）
-        critical_mode: 急所判定モード（"normal" / "always"、デフォルト"normal"）
-        damage_roll: ダメージ乱数モード（"normal" / "average" / "max" / "min"、デフォルト"normal"）
-        accuracy_fix_threshold: この値以上の命中率を100%固定にする（Noneなら無効）
-        effect_chance_threshold: この値未満の追加効果確率を0%にする（Noneなら無効）
-        double_battle: ダブルバトル向けのダメージ計算補正
-            （複数対象になり得る技のダメージ0.75倍・壁の軽減率2/3倍）を有効にするか（デフォルトFalse）
-
-    Returns:
-        Battle: セットアップ済みのBattleインスタンス
-    """
-    # プレイヤーとバトルのセットアップ
-    if not team0:
-        raise ValueError("ally must contain at least one Pokemon")
-    if not team1:
-        raise ValueError("foe must contain at least one Pokemon")
-
-    players = (CustomPlayer("Player 1"), CustomPlayer("Player 2"))
-    for player, mons in zip(players, [team0, team1]):
-        for mon in mons:
-            player.team.append(mon)
-
-    battle = Battle(
-        *players,
-        mega_evolution=mega_evolution,
-        terastal=terastal,
-        critical_mode=critical_mode,
-        damage_roll=damage_roll,
-        accuracy_fix_threshold=accuracy_fix_threshold,
-        effect_chance_threshold=effect_chance_threshold,
-        double_battle=double_battle,
-    )
-    battle.start()
-
-    if ailment0 or ailment1:
-        ailments = [ailment0, ailment1]
-        for idx, mon in enumerate(battle.actives):
-            if not ailments[idx]:
-                continue
-            name, count = ailments[idx]
-            battle.ailment_manager.apply(mon, name, count=count)
-
-    # 揮発効果の適用
-    if volatile0 or volatile1:
-        volatiles = [volatile0, volatile1]
-        for idx, mon in enumerate(battle.actives):
-            if not volatiles[idx]:
-                continue
-            for name, count in volatiles[idx].items():
-                battle.volatile_manager.apply(mon, name, count=count)
-
-    # 天候の有効化
-    if weather:
-        name, weather_count = weather
-        battle.weather_manager.apply(name, weather_count)
-
-    # 地形の有効化
-    if terrain:
-        name, terrain_count = terrain
-        battle.terrain_manager.apply(name, terrain_count)
-
-    # グローバルフィールドの有効化
-    if field:
-        for name, count in field.items():
-            battle.global_manager.activate(name, count)
-
-    # サイドフィールドの有効化（初期ターン後に実行してポケモンへのダメージを回避）
-    if side0:
-        for name, layers in side0.items():
-            battle.side_managers[0].activate(name, layers)
-    if side1:
-        for name, layers in side1.items():
-            battle.side_managers[1].activate(name, layers)
-
-    # 命中率の設定
-    if accuracy is not None:
-        battle.test_option.accuracy = accuracy
-
-    # 追加効果確率の設定
-    if secondary_chance is not None:
-        battle.test_option.secondary_chance = secondary_chance
-
-    battle.print_logs()
-
-    return battle
-
-
-def reserve_command(battle: Battle,
-                    command0: Command | None = None,
-                    command1: Command | None = None):
-    """各プレイヤーがコマンドを予約した状態にする
-
-    Args:
-        battle: Battleインスタンス
-    """
-    commands = [command0, command1]
-    with battle.phase_context("action"):
-        for i, (player, state) in enumerate(battle.player_states.items()):
-            state.reset_turn_state()
-            command = commands[i]
-            if command is None:
-                command = player.choose_command(battle)
-            state.reserve_command(command)
-
-
-def build_context(battle: Battle, atk_idx: int, move_idx: int = 0) -> AttackContext:
-    """AttackContextを構築するヘルパー関数。"""
-    attacker = battle.actives[atk_idx]
-    defender = battle.foe(attacker)
-    move = attacker.moves[move_idx]
-    return AttackContext(attacker=attacker, defender=defender, move=move)
-
-
-def run_move(battle: Battle, atk_idx: int, move_idx: int = 0) -> Move:
-    """技を実行するヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        atk_idx: 技を使用するポケモンのインデックス
-        move_idx: 使用する技のインデックス（デフォルト: 0）
-
-    Returns:
-        使用した技のインスタンス
-    """
-    attacker = battle.actives[atk_idx]
-    move = attacker.moves[move_idx]
-    battle.run_move(attacker, move)
-    battle.print_logs()
-    return move
-
-
-def run_switch(battle: Battle, player_idx: int, new_idx: int) -> Pokemon:
-    """ポケモンを入れ替えるヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        player_idx: 入れ替えるプレイヤーのインデックス
-        new_idx: 入れ替えるポケモンのインデックス
-
-    Returns:
-        入れ替えたポケモンのインスタンス
-    """
-    player = battle.players[player_idx]
-    mon = battle.player_states[player].team[new_idx]
-    battle.run_switch(player, mon)
-    return mon
-
-
-def can_switch(battle: Battle, player_idx: int) -> bool:
-    """ポケモンを入れ替え可能か判定するヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        player_idx: 判定するプレイヤーのインデックス
-
-    Returns:
-        入れ替え可能かどうか
-    """
-    player = battle.players[player_idx]
-    return battle.query.can_switch(player)
-
-
-def change_item(battle: Battle,
-                mon: Pokemon,
-                item_name: str,
-                source: Pokemon | None = None) -> bool:
-    """アイテムを変更する。
-
-    Args:
-        battle: Battleインスタンス
-        mon: アイテムを変更するポケモン
-        item_name: 変更後のアイテム名（空文字列の場合はアイテムを外す）
-        source: アイテムを変更する原因となったポケモン（例: 交換元のポケモン、技の使用者など）
-
-    Returns:
-        アイテムの変更が成功したかどうか
-    """
-    if mon.has_item(item_name):
-        return True
-
-    if not mon.has_item():
-        return battle.item_manager.gain_item(mon, item_name)
-
-    if not item_name:
-        return battle.item_manager.remove_item(mon, source=source)
-
-    if not battle.item_manager.can_change_item(mon, source=source):
-        return False
-
-    battle.item_manager._change_item(mon, item_name)
-    return True
-
-
-def end_turn(battle: Battle):
-    """ターンを終了するヘルパー関数。"""
-    battle.events.emit(Event.ON_TURN_END)
-
-
-def apply_ailment(battle: Battle,
-                  active_index: int,
-                  ailment_name: AilmentName,
-                  count: int = 1,
-                  by_foe: bool = False,
-                  overwrite: bool = False) -> bool:
-    """状態異常を適用するヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        active_index: 状態異常を適用するポケモンのインデックス
-        ailment_name: 適用する状態異常の名前
-        count: 状態異常のカウント（デフォルト: 1）
-        by_foe: 相手によって状態異常が適用されたかどうか（デフォルト: False）
-        overwrite: 既存の状態異常を上書きするかどうか（デフォルト: False）
-
-    Returns:
-        状態異常の適用が成功したかどうか
-    """
-    mon = battle.actives[active_index]
-    source = battle.foe(mon) if by_foe else None
-    return battle.ailment_manager.apply(
-        mon, ailment_name, count=count, source=source, overwrite=overwrite
-    )
-
-
-def get_action_order(battle: Battle,
-                     command0: Command | None = None,
-                     command1: Command | None = None) -> list[Pokemon]:
-    """行動順を取得するヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        command0: プレイヤー0のコマンド（Noneの場合はプレイヤーが選択）
-        command1: プレイヤー1のコマンド（Noneの場合はプレイヤーが選択）
-
-    Returns:
-        行動順のポケモンのリスト
-    """
-    reserve_command(battle, command0, command1)
-    return battle.speed_calculator.resolve_action_order()
-
-
-def fix_damage(battle: Battle, damage: int):
-    """ダメージ計算のダイスロールを固定値にする。
-
-    Args:
-        battle: Battleインスタンス
-        damage: 固定するダメージ値
-    """
-    battle.roll_damage = lambda *args, **kwargs: damage
-
-
-def fix_random(battle: Battle, value: float):
-    """乱数を固定する
-
-    Args:
-        battle: Battleインスタンス
-        value: 固定する乱数の値（0.0以上1.0未満）
-    """
-    battle.random.random = lambda: value
-
-
-def calc_lethal(battle: Battle,
-                atk_idx: int,
-                moves: Move | tuple[Move, int] | list[Move | tuple[Move, int]],
-                critical: bool = False,
-                secondary: bool = False,
-                max_attack: int = 10) -> list[LethalResult]:
-    """致死率計算を実行するヘルパー関数。
-
-    Args:
-        battle: Battleインスタンス
-        atk_idx: 攻撃側ポケモンのインデックス
-        moves: 技（単体 / (技, ヒット数) / リスト）
-        critical: 急所計算をするか（デフォルト: False）
-        secondary: 追加効果ハンドラを適用するか（デフォルト: False）
-        max_attack: 最大攻撃回数（デフォルト: 10）
-
-    Returns:
-        各ヒット後の LethalResult のリスト（確定数が出た時点で打ち切り）
-    """
-    attacker = battle.actives[atk_idx]
-    return battle.calc_lethal(
-        attacker=attacker, moves=moves, critical=critical,
-        secondary=secondary, max_attack=max_attack
-    )
-
-
-def calc_move_priority(battle: Battle, player_index: int, move_index: int = 0) -> int:
-    """技を発動したときの優先度を返す
-
-    Args:
-        battle: Battleインスタンス
-        player_index: 技を使用するポケモンのインデックス
-        move_index: 使用する技のインデックス（デフォルト: 0）
-
-    Returns:
-        技の優先度
-    """
-    mon = battle.actives[player_index]
-    move = mon.moves[move_index]
-    return battle.speed_calculator.calc_move_priority(mon, move)
+"""テストヘルパーの薄い再エクスポート層。
+
+実体は `jpoke.testing`（本体パッケージへ昇格済み）に移設した。既存テストコードの
+`from . import test_utils as t` / `from .. import test_utils as t` という参照パターンを
+壊さないための後方互換シムとして残している。新規コードは `jpoke.testing` を直接
+参照してよい。
+"""
+from jpoke.testing import (
+    CustomPlayer,
+    start_battle,
+    reserve_command,
+    build_context,
+    run_move,
+    run_switch,
+    can_switch,
+    change_item,
+    end_turn,
+    apply_ailment,
+    get_action_order,
+    fix_damage,
+    fix_random,
+    calc_lethal,
+    calc_move_priority,
+)
+
+__all__ = [
+    "CustomPlayer",
+    "start_battle",
+    "reserve_command",
+    "build_context",
+    "run_move",
+    "run_switch",
+    "can_switch",
+    "change_item",
+    "end_turn",
+    "apply_ailment",
+    "get_action_order",
+    "fix_damage",
+    "fix_random",
+    "calc_lethal",
+    "calc_move_priority",
+]


### PR DESCRIPTION
## Summary
- PyPI公開後改善タスク（`docs/plan/pypi_release.md` フェーズ4）の「`tests/test_utils.py`の主要ヘルパーをjpoke.testingとして本体パッケージへ昇格」に対応
- `src/jpoke/testing.py` を新設し、`start_battle`/`run_move`/`run_switch`等14関数+`CustomPlayer`を移植。`pip install jpoke`だけで（cloneせずに）ピンポイントな状態検証ができるようになる
- `tests/test_utils.py` は後方互換の薄い再エクスポート層に変更（既存テストの参照パターンは無変更で動作）
- 移植時に判明した内部マネージャー直呼びの箇所は、`Battle`に薄い公開ラッパーを新設して解消:
  - `Battle.set_ailment()` に `source`/`overwrite` 引数を追加（後方互換維持）
  - `Battle.set_volatile()` / `Battle.set_item()` / `Battle.activate_global_field()` / `Battle.activate_side_field()` / `Battle.resolve_action_order()` / `Battle.calc_move_priority()` / `Battle.can_switch()` / `Battle.end_turn()` を新設（`ItemManager.set_item()` も新設）
  - `fix_damage`/`fix_random`（モンキーパッチ）は公開API化せず、docstringに「テスト・デバッグ専用」と明記するに留めた
- 判断の詳細は `docs/plan/pypi_release.md` フェーズ4に記録

## Test plan
- [x] `python -m pytest tests/ -q` 4842 passed, 1 skipped
- [x] `python -m pytest tests/test_examples_smoke.py -q` 9 passed
- [x] `python -m ruff check .` All checks passed
- [x] `python -m mypy` エラーなし
- [x] `python -m build` でwheelビルド後、クリーンvenvへインストールし `import jpoke.testing` の実地確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)