### PR TITLE
perf: importlib.metadataのimportコスト除去でjpokeの初期化を高速化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,14 @@ python -m pytest tests/ -q --cov=jpoke --cov-report=term
 `.pre-commit-config.yaml` を使うと、これらのチェック（の一部）をコミット前に
 ローカルで自動実行できます（`pip install pre-commit && pre-commit install`）。
 
+## バージョン管理
+
+`pyproject.toml` の `version` と `src/jpoke/__init__.py` の `__version__` は
+（`importlib.metadata` の import コストを避けるため）二重管理になっています。
+`pyproject.toml` の `version` を上げる際は `src/jpoke/__init__.py` の
+`__version__` も同じ値に **手動で** 揃えてください。両者の不一致は
+`tests/test_version.py` が検知します。
+
 ## アーキテクチャとハンドラ追加の流れ
 
 jpoke はイベント駆動アーキテクチャを採用しています。バトルロジックが `Event` を

--- a/docs/plan/pypi_release.md
+++ b/docs/plan/pypi_release.md
@@ -281,6 +281,23 @@ package-check:
   （実験用の並び替えはコミットに含めず、`core/__init__.py` は元の順序のまま）
 - `import jpoke` の初期化コスト削減（実測 約460ms。pokedex.json 544KB と
   全ハンドラテーブルを import 時に無条件ロードしている。遅延 import の余地あり）
+  - 実施済み（1st段）: `python -X importtime -c "import jpoke"` の計測で総コストの
+    約35%（約78〜80ms）が `src/jpoke/__init__.py` の
+    `from importlib.metadata import version as _version` 経由の
+    `importlib.metadata` import（re, json, email, ast, dis, tokenize, inspect,
+    pathlib, zipfile, textwrap 等を連鎖 import する重いモジュール）に起因すると
+    判明したため、`__version__` をリテラル `"0.1.0"`（`pyproject.toml` の
+    version と同値）へ変更して `importlib.metadata` の import 自体を除去した。
+    `pyproject.toml` の version と二重管理になるリスクは
+    `tests/test_version.py` を新設して機械的に検証することで担保した
+    （`pyproject.toml` を正規表現で読む方式。プロジェクトが Python 3.10+ 対応のため
+    `tomllib`〈3.11+ 標準〉単体には依存しない）。importtime 実測: 修正前
+    総コスト約243〜273ms（3回計測、`importlib.metadata` 単体で約80ms） →
+    修正後は `importlib.metadata` のブロックが importtime 出力から消滅し、
+    総コストも有意に減少（実測値は該当PRの報告を参照）
+  - 残課題（2nd段、未着手）: pokedex.json 544KB の読み込み（実測 約11ms、
+    全体の約5%）と全ハンドラテーブルの無条件ロードの遅延 import 化は
+    別件として保留中
 - CONTRIBUTING.md / SECURITY.md の整備
 - 実施済み: `CONTRIBUTING.md`（開発環境セットアップ・テスト実行・コードスタイル・
   ハンドラ追加の流れ・ブランチ/PRの流れ・対象範囲の注意）と `SECURITY.md`

--- a/docs/tests/test_version.md
+++ b/docs/tests/test_version.md
@@ -1,0 +1,5 @@
+# test_version
+
+テスト数: 1
+
+- [x] バージョン番号がpyproject_tomlとsrc_jpoke初期化ファイルで一致している

--- a/src/jpoke/__init__.py
+++ b/src/jpoke/__init__.py
@@ -3,13 +3,12 @@
 バトル、プレイヤー、ポケモン、技、特性、アイテムなどの主要クラスと、
 ポケモン図鑑データを提供します。
 """
-from importlib.metadata import version as _version
-
 from .core import Battle, Player
 from .model import Pokemon, Ability, Item, Move
 from .data import POKEDEX
 
-__version__ = _version("jpoke")
+# pyproject.toml の version と手動で一致させること（tests/test_version.py で検証）
+__version__ = "0.1.0"
 
 __all__ = [
     "Battle",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,37 @@
+"""バージョン番号の二重管理チェック。
+
+`jpoke.__version__` は `importlib.metadata` の import コストを避けるため
+`pyproject.toml` の `version` とは独立したリテラルとして `src/jpoke/__init__.py`
+に直書きしている。手動同期が前提のため、両者がズレていないかを検証する。
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+import jpoke
+
+def _pyproject_version() -> str:
+    """pyproject.toml の [project] version を正規表現で抽出する。
+
+    プロジェクトは Python 3.10+ を対象としており `tomllib`（3.11+ 標準）を
+    単体では使えないため、正規表現による軽量な抽出で代替する。
+    """
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    assert match is not None, "pyproject.toml に version 行が見つからない"
+    return match.group(1)
+
+
+def test_バージョン番号がpyproject_tomlとsrc_jpoke初期化ファイルで一致している():
+    """`pyproject.toml` の version と `jpoke.__version__` が一致することを確認する。
+
+    `pyproject.toml` の version を上げる際は `src/jpoke/__init__.py` の
+    `__version__` も同じ値に手動で揃える必要がある。このテストがズレを検知する。
+    """
+    assert jpoke.__version__ == _pyproject_version()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- `import jpoke` の初期化コスト（実測約220ms）のうち約35%（約78〜80ms）を占めていた `importlib.metadata` 経由のバージョン取得を除去
- `src/jpoke/__init__.py` の `__version__` を `pyproject.toml` と同値のリテラルに変更し、`importlib.metadata` の import自体をなくした
- `pyproject.toml` とのバージョン不一致を検知する `tests/test_version.py` を新設し、二重管理のリスクを機械的にガード

## Test plan
- [x] `python -m pytest tests/test_version.py -v` 通過
- [x] `python -m ruff check .` 通過
- [x] `python -m mypy` エラーなし
- [x] importtimeで `importlib.metadata` ブロックの消滅を確認
- [ ] `python -m pytest tests/ -q` 全体通過（実行中、確認後追記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)