### PR TITLE
chore: impl/review-testエージェント指示書のフロー依存重複を整理

### DIFF
--- a/.claude/agents/impl.md
+++ b/.claude/agents/impl.md
@@ -22,12 +22,11 @@ tools:
 - `handlers/` に実装関数を追加し、`data/` にハンドラを登録する
 - テストは書かない（`review-test` エージェントが担当）
 
-## ブランチ管理
+## ブランチ・ソート運用
 
-ループから呼ばれる場合、プロンプトに `git checkout -B "loop/impl/{entry}" loop/impl/integration`
-が含まれる（統合ブランチ `loop/impl/integration` の先端から entry ブランチを作成する）。
-必ず指示通りにブランチを作成してから実装を開始し、完了後はコミットして
-`loop/impl/integration` へ detach で戻ること（`git checkout --detach loop/impl/integration`）。
+ブランチの作成・切替・コミットのタイミング、五十音ソートスクリプト（`sort_handlers.py` /
+`sort_data/*.py`）を今回実行するかどうかは、呼び出し元プロンプトの指示に従う
+（フローにより異なる。単一ブランチ系は都度ソート、統合ブランチ系はマージ後に一括ソート）。
 
 ## 成果物チェックリスト
 
@@ -36,9 +35,6 @@ tools:
 - [ ] `handlers/` に関数を追加した
 - [ ] `data/` でハンドラを登録した
 - [ ] 新しい `Literal` 型が必要なら `types/` に追加した
-- [ ] `python scripts/sort_handlers.py src/jpoke/handlers/<category>.py` を実行した
-- [ ] `data/ability.py` / `data/item.py` / `data/move.py` を変更した場合、対応するスクリプト（`scripts/sort_data/sort_abilities.py` / `scripts/sort_data/sort_items.py` / `scripts/sort_data/sort_moves.py`）を実行した
 - [ ] `docs/progress/<category>.md` の実装列（実装）を `x` に更新した
-- [ ] 変更をコミットした（`git add -A && git commit -m "impl: {entry}"`）
-- [ ] `loop/impl/integration` に detach で戻った（`git checkout --detach loop/impl/integration`）
+- [ ] プロンプトの指示通りにコミット・ブランチ操作を行った
 - [ ] `review-test` に渡すべき仕様上の注意点・エッジケースをまとめた

--- a/.claude/agents/review-test.md
+++ b/.claude/agents/review-test.md
@@ -22,19 +22,13 @@ tools:
 - `tests/` にテストを追加して全件パスを確認する
 - `docs/progress/` と `docs/test/` を更新する
 
-## ブランチ管理
+## ブランチ・ソート運用
 
-ループから呼ばれる場合、作業ディレクトリは impl 完了済みの `loop/impl/{entry}` ブランチ（impl と
-同一ブランチ）を checkout した使い捨て worktree になっている
-（例: `{config.worktree_base}\review`）。
-その worktree 内で作業し、完了後は同じブランチ上に変更をコミットすること。
-ブランチの統合ブランチへのマージ・worktree の削除はループディスパッチャーが担当するため、
-エージェント側では行わない。
-
-## 結果ファイルの書き込み
-
-作業ディレクトリが worktree の場合、結果ファイルはメインリポジトリの `.loop/review_results/` に書く
-（プロンプトに絶対パスが記載される）。
+作業ディレクトリ（永続ブランチ直下か使い捨て worktree か）、コミット先ブランチ、五十音ソート・
+`sort_tests.py`・`generate_test_list.py` を今回実行するかどうかは、呼び出し元プロンプトの指示に従う
+（フローにより異なる。単一ブランチ系は都度ソート・一覧更新、統合ブランチ系はマージ後に一括実行）。
+統合ブランチへのマージ・worktree の削除はループディスパッチャーが担当するためエージェント側では
+行わない。結果ファイル（`.ok`/`.fail`）の書き込み先はプロンプトに絶対パスで記載される。
 
 ## レビュー観点
 
@@ -59,11 +53,8 @@ tools:
 完了時に確認して報告する：
 
 - [ ] レビュー指摘があれば修正した
-- [ ] handlers を修正した場合は `python scripts/sort_handlers.py src/jpoke/handlers/<category>.py` を実行した
-- [ ] `data/ability.py` / `data/item.py` / `data/move.py` を修正した場合、対応するスクリプト（`scripts/sort_data/sort_abilities.py` / `scripts/sort_data/sort_items.py` / `scripts/sort_data/sort_moves.py`）を実行した
-- [ ] テストを追加して `python scripts/sort_tests.py <テストファイル>` でソートした
-- [ ] `python scripts/generate_test_list.py` を実行して `docs/tests/` を更新した
+- [ ] テストを追加した
 - [ ] `python -m pytest tests/ -v` で全件パスした
 - [ ] `docs/progress/<category>.md` の全列（マーク・効果列の説明文を含む）を実際の状態と照合し、テスト済みマークを更新した
-- [ ] 変更をコミットした（`git add -A && git commit -m "review: {entry}"`）
+- [ ] プロンプトの指示通りにソート・テスト一覧更新・コミット・ブランチ操作を行った
 - [ ] 結果ファイルを書き込んだ（`.ok` または `.fail`）


### PR DESCRIPTION
## Summary
- \`impl\`/\`review-test\` エージェント定義（\`.claude/agents/*.md\`）のチェックリストから、フローごとに実行タイミングが異なるソートスクリプト実行・ブランチ運用の固定記述を削除
- 統合ブランチ系フロー（impl/review）の「マージ後一括ソート」方針と、旧チェックリストの「都度ソート実行」記述が矛盾していたため、呼び出し元プロンプトの指示に従う旨の一文に統合
- レビュー観点（subject_spec整合性・五十音順・進捗表整合性チェックなど）はループ側プロンプトに無い実質的な価値があるため維持

## Test plan
- ドキュメントのみの変更のため、テスト実行は不要
- 次回 /loop impl または /loop review 実行時に、意図通り呼び出し元プロンプトの指示（ソート要否）に従って動作することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)