### PR TITLE
api: r7-2 Pokemon.set_form()のドキュメント・サンプル追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@
   委譲として追加。`can_switch()` 以外は `battle.query.<method>()` の直接呼び出しが
   必要で `docs/api/README.md` にも未掲載だったための対応（`AttackContext`/
   `EventContext` を要求する内部専用メソッドは対象外のまま）
+- `docs/api/README.md`（Pokemon「シナリオ構築系（フォルム変化）」）に
+  `Pokemon.set_form(name, hp_policy="keep_absolute", set_default_ability=False)` を追記。
+  実装済み（ロトム・ザシアン/ザマゼンタ・オリジンフォルム等の切り替えに内部で使用）
+  ながら `docs/api/README.md`・`examples/` のどちらにも未掲載だったための対応。
+  合わせて `examples/03_damage_calc/10_form_change_comparison.py` を新設し、
+  `set_form()` によるロトムのフォルム変化がタイプ・種族値を通じてダメージ・致死率に
+  与える影響を比較するサンプルを追加
 
 ### Changed
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -419,6 +419,23 @@ print(mon.status, mon.has_ailment("どく"), mon.has_volatile("こんらん"))
 print(mon.fainted, mon.hp, mon.max_hp)
 ```
 
+### シナリオ構築系（フォルム変化）
+
+| API | 概要 |
+|---|---|
+| `set_form(name, hp_policy="keep_absolute", set_default_ability=False)` | フォルムをエイリアス（図鑑上の別名）指定で切り替える。種族値・タイプ・特性候補が変更先のものに差し替わる（ロトムの姿、ザシアン/ザマゼンタの剣王/盾王、ディアルガ等のオリジンフォルムなど）。既に同じフォルムなら何もせず `False` を返す。`hp_policy` は最大HPが変化したときの現在HPの追従方法（`set_evs`/`set_ivs`と共通）。`set_default_ability=True` の場合、特性を変更先の先頭特性にリセットする |
+
+```python
+mon = Pokemon("ロトム")           # でんき/ゴースト
+mon.set_form("ヒートロトム")       # でんき/ほのお に切り替わる（種族値・タイプ込み）
+print(mon.types, mon.stats)
+```
+
+`Battle` の「シナリオ構築系」（`modify_hp`/`set_ailment`等、[上記参照](#シナリオ構築系)）と
+同じく対戦を進行させずに状態を直接組み立てるためのメソッドだが、`set_form` は `Pokemon`
+自身のメソッドである点に注意（`Battle` 側に委譲ラッパーは無く、`mon.set_form(...)` の形で
+直接呼ぶ）。
+
 ## Command
 
 `src/jpoke/enums/command.py`。プレイヤーの1回の行動（技使用・交代・テラスタル等）を表す

--- a/docs/api_feedback/loop_rounds/round7.md
+++ b/docs/api_feedback/loop_rounds/round7.md
@@ -25,3 +25,28 @@
   （`def`側で`60 == 80`のような不一致、`spe`側で`110 == 142`のような不一致）を確認したうえで
   修正版に戻し、`python -m pytest tests/ -v`で5757件全件パス（既存のflaky testの新規発生なし）を
   確認した。
+
+- [x] `Pokemon.set_form()`（フォルムチェンジ）が実装済みなのにexamples・docsに一度も登場しない
+  （developer視点、id: r7-2） → 対応内容 (2026-07-14): `src/jpoke/model/pokemon.py:538`の
+  `set_form(name, hp_policy="keep_absolute", set_default_ability=False)`は種族値・タイプ・
+  特性候補込みでフォルム（ロトムの姿、ザシアン/ザマゼンタの剣王/盾王、オリジンフォルム等）を
+  切り替えられる実用APIだが、`docs/api/README.md`・`examples/`のいずれにも記載が無かった。
+  `docs/api/README.md`のPokemonセクションに「シナリオ構築系（フォルム変化）」を新設し
+  `set_form()`のシグネチャ・引数・戻り値（既に同じフォルムなら何もせず`False`を返す）を明記した。
+  合わせて`examples/03_damage_calc/10_form_change_comparison.py`を新設し、ロトムの全6フォルム
+  （ベース/ヒート/ウォッシュ/フロスト/スピン/カット）に「じしん」を撃った場合のダメージ・
+  致死率と、フォルムごとのぼうぎょ実数値を`calc_lethal()`と組み合わせて比較するサンプルを追加
+  （`examples/README.md`にも一覧追加）。`PYTHONIOENCODING=utf-8 python
+  examples/03_damage_calc/10_form_change_comparison.py`で実行し、タイプ相性（ヒートロトムは
+  じめん4倍弱点、スピンロトムは無効化等）・種族値差が出力に正しく反映されることを確認した。
+  回帰テストとして`tests/test_form.py`を新設し6件追加した:
+  `set_form`が同じフォルム指定時に何も変更せず`False`を返すこと、異なるフォルム指定で
+  種族値・タイプが切り替わり`True`を返すこと（ロトム→ヒートロトム）、既定の
+  `hp_policy="keep_absolute"`では最大HPが変化するフォルム変化（ジガルデ50%→10%、HP種族値
+  108→54）でも被ダメージ絶対量が維持されること、`hp_policy="reset"`では被ダメージ状態でも
+  満タンになること、`set_default_ability`未指定時は変更先の特性候補（ジガルデ(パーフェクト)は
+  スワームチェンジのみ）に含まれるかに関わらず元の特性（オーラブレイク）が維持されること、
+  `set_default_ability=True`指定時は変更先の先頭特性（スワームチェンジ）にリセットされること。
+  `python scripts/sort_tests.py tests/test_form.py`・`python scripts/generate_test_list.py`を
+  実行し、`python -m pytest tests/ -v`で5764件全件パス（既存の5757件+新規テスト6件+examplesスモーク
+  1件、flaky testの新規発生なし）を確認した。

--- a/docs/tests/test_form.md
+++ b/docs/tests/test_form.md
@@ -1,0 +1,10 @@
+# test_form
+
+テスト数: 6
+
+- [x] set_form_hp_policyでresetを指定すると被ダメージ状態でも満タンになる
+- [x] set_form_keep_absoluteが既定で被ダメージ絶対量が維持される
+- [x] set_form_set_default_abilityにTrueを指定すると変更先の先頭特性にリセットされる
+- [x] set_form_set_default_abilityを指定しない場合は特性が維持される
+- [x] set_form_同じフォルムを指定すると何も変更されずFalseが返る
+- [x] set_form_異なるフォルムを指定すると種族値タイプが切り替わりTrueが返る

--- a/examples/03_damage_calc/10_form_change_comparison.py
+++ b/examples/03_damage_calc/10_form_change_comparison.py
@@ -1,0 +1,61 @@
+"""jpoke で学べること: Pokemon.set_form() によるフォルム変化がダメージ計算に与える影響。
+
+ロトムはフォルムごとにタイプ・種族値が異なる（例: ヒートロトムはでんき/ほのお、
+スピンロトムはでんき/ひこう）。set_form() はエイリアス（図鑑上の別名）を指定して
+対戦を進行させずにフォルムを直接切り替えられるため、calc_lethal() と組み合わせて
+「同じ技でもフォルムが変わるだけで結果がどう変わるか」を比較できる。
+"""
+from __future__ import annotations
+
+from jpoke import Battle, Player
+
+
+def main() -> None:
+    move_name = "じしん"  # じめんタイプの物理技。でんきタイプに効果抜群、ひこうタイプには無効
+
+    attacker_player = Player("Attacker")
+    attacker_player.add_pokemon("ガブリアス", move_names=[move_name])
+    defender_player = Player("Defender")
+    defender_player.add_pokemon("ロトム")  # でんき/ゴースト（ベースフォルム）
+
+    battle = Battle(attacker_player, defender_player, seed=1)
+    battle.start()
+    attacker = battle.get_active(attacker_player)
+    defender = battle.get_active(defender_player)
+
+    # set_form(name, hp_policy="keep_absolute", set_default_ability=False) は
+    # エイリアス指定でフォルムを切り替える。種族値・タイプ・特性候補が変更先のものに
+    # 差し替わる（戻り値は実際に切り替わったかを示す bool）。
+    # ロトムは全フォルムでH種族値が同じ(50)ため、既定の hp_policy="keep_absolute" でも
+    # 現在HPは変化しない
+    forms = [
+        "ロトム",          # でんき/ゴースト: じめん2倍弱点
+        "ヒートロトム",      # でんき/ほのお: じめん4倍弱点
+        "ウォッシュロトム",   # でんき/みず: じめん2倍弱点
+        "フロストロトム",     # でんき/こおり: じめん2倍弱点
+        "スピンロトム",      # でんき/ひこう: じめん完全無効
+        "カットロトム",      # でんき/くさ: じめん等倍
+    ]
+
+    print(f"{move_name}（じめんタイプ）を各フォルムのロトムに撃った場合の致死率:")
+    for form in forms:
+        defender.set_form(form)
+        final = battle.calc_lethal(attacker=attacker, moves=move_name, max_attack=1)[-1]
+        print(
+            f"  {defender.name}（{'/'.join(defender.types)}）: "
+            f"ダメージ {final.min_damage}~{final.max_damage} / 致死率 {final.lethal_probability:.2%}"
+        )
+
+    # set_form() は種族値も差し替えるため、耐久力そのものも比較すると分かりやすい
+    print("-" * 50)
+    print("フォルムごとのぼうぎょ実数値（種族値も切り替わっている）:")
+    for form in forms:
+        defender.set_form(form)
+        print(f"  {defender.name}: ぼうぎょ実数値 {defender.stats['def']}")
+
+    # 試してみよう: move_name を「なみのり」（みずタイプ）に変えると、
+    # ウォッシュロトムだけ無効になるなど、また違うフォルム差が見られる
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@ python examples/01_basics/01_battle_against_intro.py
 | `03_damage_calc/07_ailment_and_volatile.py` | 技を実際に当てて状態異常を発生させる方法、`battle.set_volatile()` による揮発性状態（やどりぎのタネ）の直接付与、`effect_chance_threshold` による追加効果発動確率の固定 | ダメージ計算ツール開発 |
 | `03_damage_calc/08_ability_and_item_logs.py` | `battle.step()` を伴う進行での特性・アイテムの発動ログ確認 | ダメージ計算ツール開発 |
 | `03_damage_calc/09_testing_helpers.py` | `jpoke.testing` の `start_battle()` / `apply_ailment()` / `run_move()` / `calc_lethal()` による、定型的なセットアップを短く書くショートカット | ダメージ計算ツール開発 |
+| `03_damage_calc/10_form_change_comparison.py` | `Pokemon.set_form()` によるフォルム変化（ロトムの姿）がタイプ・種族値の違いを通じてダメージ・致死率に与える影響の比較 | ダメージ計算ツール開発 |
 | `04_research/01_bulk_simulation.py` | `Player.battle_against()` による多数回対戦・構成比較 | 戦術研究（構成比較） |
 | `04_research/02_replay.py` | `Battle.build_replay_data()` / `ReplayPlayer` / `replay_battle()` によるリプレイの記録・再生 | 戦術研究（対戦の記録・解析） |
 | `04_research/03_janken_nash_cfr.py` | `Battle.copy()` を使ったロールアウトベースのregret matching（CFR風）による、HP状況に応じた適応的な戦略の自己対戦学習 | 戦術研究（読み合いの定量分析、発展） |

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,78 @@
+"""Pokemon.set_form()（フォルムチェンジ）のテスト"""
+import pytest
+
+from jpoke import Pokemon
+
+
+def test_set_form_hp_policyでresetを指定すると被ダメージ状態でも満タンになる():
+    mon = Pokemon("ジガルデ(50%)")
+    mon.hp = mon.max_hp - 10  # このテストに限り直接代入で被ダメージ状態を作る
+
+    mon.set_form("ジガルデ(10%)", hp_policy="reset")
+
+    assert mon.hp == mon.max_hp
+
+
+def test_set_form_keep_absoluteが既定で被ダメージ絶対量が維持される():
+    """既定のhp_policy="keep_absolute"では、最大HPが変化するフォルム変化でも
+    被ダメージの絶対量（max_hp - hp）が維持される。"""
+    mon = Pokemon("ジガルデ(50%)")
+    mon.hp = mon.max_hp - 10  # このテストに限り直接代入で被ダメージ状態を作る
+    max_hp_before = mon.max_hp
+
+    mon.set_form("ジガルデ(10%)")  # HP種族値が108→54に大きく減少するフォルム
+
+    assert mon.max_hp != max_hp_before
+    assert mon.max_hp - mon.hp == 10
+
+
+def test_set_form_set_default_abilityにTrueを指定すると変更先の先頭特性にリセットされる():
+    mon = Pokemon("ジガルデ(50%)", ability_name="オーラブレイク")
+
+    mon.set_form("ジガルデ(パーフェクト)", set_default_ability=True)
+
+    assert mon.ability.name == "スワームチェンジ"
+    assert mon.base_ability == "スワームチェンジ"
+
+
+def test_set_form_set_default_abilityを指定しない場合は特性が維持される():
+    """set_default_abilityの既定はFalseで、フォルム変化前の特性がそのまま維持される
+    （変更先の候補特性一覧に含まれるかどうかに関わらず変更されない）。"""
+    mon = Pokemon("ジガルデ(50%)", ability_name="オーラブレイク")
+
+    # ジガルデ(パーフェクト)の特性候補はスワームチェンジのみで、オーラブレイクは含まれない
+    mon.set_form("ジガルデ(パーフェクト)")
+
+    assert mon.ability.name == "オーラブレイク"
+    assert mon.base_ability == "オーラブレイク"
+
+
+def test_set_form_同じフォルムを指定すると何も変更されずFalseが返る():
+    mon = Pokemon("ロトム")
+    types_before = list(mon.types)
+    stats_before = dict(mon.stats)
+
+    result = mon.set_form("ロトム")
+
+    assert result is False
+    assert mon.name == "ロトム"
+    assert mon.types == types_before
+    assert mon.stats == stats_before
+
+
+def test_set_form_異なるフォルムを指定すると種族値タイプが切り替わりTrueが返る():
+    """set_formはエイリアス指定でフォルムを切り替え、種族値・タイプは変更先のものに
+    差し替わる（ロトム→ヒートロトム: でんき/ゴースト → でんき/ほのお）。"""
+    mon = Pokemon("ロトム")
+
+    result = mon.set_form("ヒートロトム")
+
+    assert result is True
+    assert mon.name == "ヒートロトム"
+    assert mon.types == ["でんき", "ほのお"]
+    # ぼうぎょ種族値がロトム(60)からヒートロトム(107)に切り替わっている
+    assert mon.stats["def"] > 100
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Pokemon.set_form()（フォルムチェンジ）が実装済みなのにexamples・docsに一度も登場していなかった問題を解消（id: r7-2、apiループ第7ラウンド）
- docs/api/README.md にset_form()を掲載、examples/03_damage_calc/にフォルム差の効果を比較するサンプルを追加
- 回帰テスト6件を追加

🤖 Generated with jpoke apiループ