### PR TITLE
api: r7-4 README.mdクイックスタートの旧judge_winnerパターンを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,12 @@
 
 ### Fixed
 
+- README.md の「クイックスタート」節が `while battle.judge_winner() is None and
+  battle.turn < 100:` / `winner = battle.judge_winner()` という旧パターンのままで、
+  `examples/01_basics/02_quickstart.py`（docstringで「READMEのクイックスタートと
+  同内容」と明記）や `docs/api/README.md` が採用している `while not battle.finished
+  and battle.turn < 100:` / `winner = battle.winner` という表記と食い違っていたため
+  修正し、表記を統一した（`judge_winner()` 自体は引き続き公開APIとして利用可能）
 - `Battle(seed=None)` のフォールバックが `int(time.time())`（秒精度）だったため、
   短時間に複数の `Battle` を生成すると同一シードになり、`Player.battle_against()`
   などの多数回対戦がすべて同じ展開になってしまう問題を修正。OSの乱数源から

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ player2.add_pokemon("フシギダネ", move_names=["たいあたり"])
 battle = Battle(player1, player2)
 battle.start()
 
-while battle.judge_winner() is None and battle.turn < 100:
+while not battle.finished and battle.turn < 100:
     # commands=None の場合は各 Player.choose_command() が使われる
     # （デフォルト実装は利用可能な最初のコマンドを選ぶだけの単純なプレイヤー）
     battle.step()
 
-winner = battle.judge_winner()
+winner = battle.winner
 print(winner.username if winner else "引き分け")   # 勝者の名前（決着しなかった場合はNone）
 battle.print_logs()                 # このターンのログを表示
 ```

--- a/docs/api_feedback/loop_rounds/round7.md
+++ b/docs/api_feedback/loop_rounds/round7.md
@@ -70,3 +70,22 @@
   既存の`tests/test_battle_option.py`（`resolve_secondary_chance`関連19件）が引き続き通ることを
   確認した。`python -m pytest tests/ -v`で5764件全件パス（既存件数のまま、flaky testの新規発生
   なし）を確認した。
+
+- [x] README.mdのクイックスタートだけ`judge_winner() is None`の旧パターンのまま残っている
+  （beginner視点、id: r7-4） → 対応内容 (2026-07-14): ルート`README.md`の「クイックスタート」節が
+  `while battle.judge_winner() is None and battle.turn < 100:` / `winner = battle.judge_winner()`
+  という旧パターンのままで、`examples/01_basics/02_quickstart.py`（docstringで「READMEの
+  クイックスタートと同内容」と明記）や`docs/api/README.md`が採用している`while not
+  battle.finished and battle.turn < 100:` / `winner = battle.winner`という表記と食い違って
+  いた。`README.md`を後者の表記に修正し、`CHANGELOG.md`にも明記した。`docs/api/README.md`は
+  既に`while not battle.finished` / `battle.winner`を使用しており矛盾がないため更新不要と
+  判断した。回帰テストとして`tests/test_code_conventions.py`に
+  `test_READMEがjudge_winnerのis_None比較を使っていない`を追加した。既存の
+  `test_examplesがjudge_winnerのis_None比較を使っていない`（id: r6-4）は`examples/`配下のみを
+  検査対象としており、リポジトリルートの`README.md`は検査範囲外だったため、同様の正規表現
+  （`judge_winner\(\)\s*is\s*(not\s+)?None`）でREADME.md単体を検査する専用テストを追加し、
+  同種の表記揺れが再発した場合に検出できるようにした。修正前の旧パターンに一時的に戻して
+  新規テストが失敗することを確認したうえで修正版に戻し、
+  `python scripts/sort_tests.py tests/test_code_conventions.py`・
+  `python scripts/generate_test_list.py`を実行し、`python -m pytest tests/ -v`で5765件全件
+  パス（既存の5764件+新規テスト1件、flaky testの新規発生なし）を確認した。

--- a/docs/tests/test_code_conventions.md
+++ b/docs/tests/test_code_conventions.md
@@ -1,8 +1,9 @@
 # test_code_conventions
 
-テスト数: 7
+テスト数: 8
 
 - [x] Pokemon_modify_hpが公開APIとして露出していない
+- [x] READMEがjudge_winnerのis_None比較を使っていない
 - [x] consume_itemの引数名がtargetにリネームされている
 - [x] docs_examplesがjpoke_testingモジュールに言及している
 - [x] examplesがjudge_winnerのis_None比較を使っていない

--- a/tests/test_code_conventions.py
+++ b/tests/test_code_conventions.py
@@ -15,6 +15,7 @@ from . import test_utils as t
 
 SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "jpoke"
 EXAMPLES_ROOT = Path(__file__).resolve().parent.parent / "examples"
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
 
 # 直接代入が許可されているファイル（相対パス、"/" 区切り）
 # - model/pokemon.py: hp の実体を保持するクラス自身の実装
@@ -48,6 +49,33 @@ def test_Pokemon_modify_hpが公開APIとして露出していない():
     """
     assert not hasattr(Pokemon, "modify_hp")
     assert hasattr(Pokemon, "_modify_hp_raw")
+
+
+def test_READMEがjudge_winnerのis_None比較を使っていない():
+    """`battle.judge_winner()` は決着判定のたびにTOD判定込みで再計算する重い遅延判定APIで、
+    決着したかどうかのチェックには軽量な `battle.finished`（キャッシュされた `battle.winner`
+    を経由）を使うべきという規約になっている。`judge_winner() is None` / `is not None` の
+    直接比較は `battle.finished` への置き換え漏れの兆候である。examples/ 配下は
+    `test_examplesがjudge_winnerのis_None比較を使っていない`（id: r6-4）で既に検査対象だが、
+    ルート `README.md` の「クイックスタート」節は対象外で、`while battle.judge_winner() is
+    None and battle.turn < 100:` / `winner = battle.judge_winner()` という旧パターンが
+    `examples/01_basics/02_quickstart.py` や `docs/api/README.md` の表記と食い違ったまま
+    長期間残っていた（id: r7-4）。再発防止のため README.md に `judge_winner()` の
+    `is None` / `is not None` 直接比較が無いことを確認する（`judge_winner()` 自体は
+    勝者取得APIとして今後も使われてよく、禁止対象は None との直接比較のみ）。
+    """
+    pattern = re.compile(r"judge_winner\(\)\s*is\s*(not\s+)?None")
+    text = README_PATH.read_text(encoding="utf-8")
+    violations = [
+        f"README.md:{lineno}: {line.strip()}"
+        for lineno, line in enumerate(text.splitlines(), start=1)
+        if pattern.search(line)
+    ]
+
+    assert not violations, (
+        "README.md で judge_winner() の is None / is not None 直接比較を検出"
+        "（battle.finished / battle.winner に置き換えること）:\n" + "\n".join(violations)
+    )
 
 
 def test_consume_itemの引数名がtargetにリネームされている():


### PR DESCRIPTION
## Summary
- README.mdのクイックスタートだけjudge_winner() is Noneの旧パターンのまま残っていた問題を解消（id: r7-4、apiループ第7ラウンド）
- while not battle.finished / battle.winner に統一
- README.mdの旧パターン再発防止テストを追加

🤖 Generated with jpoke apiループ