### PR TITLE
api: r7-8 Battle.copy()にcopy_logsオプションを追加し木探索のコピー負荷を軽減

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@
   「テストユーティリティ」節のインデックス指定版 `jpoke.testing.calc_move_priority(battle,
   player_index, move_index=0)` のみが記載されていたための対応。両者の違い
   （`Pokemon`/`Move` オブジェクト指定かインデックス指定か）を相互に明記した
+- `Battle.copy(copy_logs=False)` — `event_logger`/`command_log`（対戦開始からの
+  全履歴）をdeepcopyせず、複製先に空の新規ログを持たせるオプション引数を追加。
+  `copy_logs=False` を指定すると、複製元のログには影響を与えずにコピー負荷を
+  抑えられる。既定は `True` で従来通りの挙動を維持する。`TreeSearchPlayer`
+  の内部シミュレーション（`evaluate()` の既定実装はログを一切参照しない）で
+  `copy_logs=False` を使うように変更し、探索ノードごとに発生していた
+  全履歴の無駄なdeepcopyを削減した
 
 ### Changed
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -237,6 +237,19 @@ critical_hits = [
 ]
 ```
 
+### 複製系
+
+| API | 概要 |
+|---|---|
+| `copy(reseed=False, copy_logs=True)` | `Battle` インスタンスを複製する。`reseed=True` にすると複製側の `random`/`decision_random` を派生シードで再初期化し、木探索で兄弟ノード間の乱数系列が相関するのを避けられる（複製元の乱数系列は消費されない）。`copy_logs=False` にすると `event_logger`/`command_log`（対戦開始からの全履歴）をdeepcopyせず、複製先に空の新規ログを持たせる（複製元のログには影響しない）。木探索の内部シミュレーションのようにログを参照しない用途では、ターン数に比例して増える全履歴コピーのコストを避けられる |
+
+```python
+sim = battle.copy(reseed=True, copy_logs=False)
+sim.step({player1: command1, player2: command2})
+# sim.get_event_logs() は copy() 以降に発生したログのみを返す
+# （複製元 battle の履歴は sim には含まれない）
+```
+
 ### poke-env互換プロパティ
 
 `observer`（プレイヤー視点）が設定されている前提のプロパティ群。方策実装（`choose_command()`）に

--- a/docs/api_feedback/loop_rounds/round7.md
+++ b/docs/api_feedback/loop_rounds/round7.md
@@ -174,3 +174,48 @@
   `python -m pytest tests/ -v`で5779件全件パス・1件skip（新規テスト2件を含む。main側で他ラウンド
   由来のテストが追加され件数はr7-6時点の5769件から増えている。flaky testの新規発生なし）を
   確認した。
+
+- [x] `Battle.copy()`がevent_logger/command_logを毎回まるごとdeepcopyし、木探索のノード数×
+  経過ターン数に比例してコピー負荷が膨張する（ai_developer視点、id: r7-8） → 対応内容
+  (2026-07-14): `src/jpoke/core/battle.py:326`の`copy()`は複製のたびに対戦開始からの全履歴
+  （`event_logger.logs`/`command_log`）を`_EXTRA_DEEPCOPY_KEYS`経由で無条件にdeepcopyしており、
+  `TreeSearchPlayer`の内部シミュレーション（探索ノード1つにつき1回`copy()`が呼ばれる）では
+  ログを一切参照しないにもかかわらずターン経過とともにこのコストだけが線形に増えていた。
+  `copy(reseed=False, copy_logs=True)`に`copy_logs`引数を追加し、`False`指定時は
+  複製元の`event_logger`/`command_log`を一時的に空の新規オブジェクト（`EventLogger()`/`[]`）に
+  差し替えたうえで`deepcopy(self)`を行い、`finally`節で直ちに複製元へ復元する方式にした
+  （`fast_copy()`は`_EXTRA_DEEPCOPY_KEYS`に列挙されたキーを`deepcopy(val)`するだけなので、
+  差し替え後は空オブジェクトをdeepcopyするだけになり、全履歴コピーのコストを避けつつ複製先には
+  複製元と独立した新規の空ログを持たせられる）。レビューで実装方式を精査し、(1)
+  `deepcopy(self)`実行中に例外が発生しても`finally`で複製元のログが確実に復元されること、
+  (2) `event_logger`/`command_log`を参照する属性が`Battle`自身以外に存在しない
+  （`grep`で確認）ため、一時差し替えによる意図しない波及がないこと、(3) 複製先への書き込みが
+  複製元を汚染しないこと（実測で確認）、(4) `TreeSearchPlayer`以外に`event_logger`/
+  `command_log`を参照するコードが`_worst_case_over_opponent()`内に無いため`copy_logs=False`が
+  安全なこと、を確認した。スレッドセーフではない点は`build_observation()`と同様のためdocstringに
+  `Warning`として明記した。`CHANGELOG.md`の一覧記載に`copy_logs=True`という誤記
+  （実際に新規挙動を有効化するのは`copy_logs=False`）を見つけ`copy_logs=False`に修正し、
+  直前の箇条書きとの間に紛れ込んでいた余分な空行も削除した。`docs/api/README.md`の「複製系」
+  節・コード例は実装と一致していることを確認した。`src/jpoke/players/tree_search_player.py:268`の
+  `_worst_case_over_opponent()`内`sim = battle.copy(reseed=True)`は`sim = battle.copy(reseed=True,
+  copy_logs=False)`に変更済みで、既定の`evaluate()`実装がログを参照しないことと整合する。
+  回帰テストとして`tests/test_copy.py`に4件追加した:
+  `test_copy_logsTrueで従来通りログの全履歴が引き継がれる`は既定（`copy_logs`省略）で複製先の
+  `event_logger.logs`が複製元と同一件数・同一内容になることを確認する。
+  `test_copy_logsFalseで複製先のログが空になる`は`copy_logs=False`で複製先の`event_logger.logs`/
+  `command_log`が空リストになり、かつ複製元とは別オブジェクト（共有参照でない）であることを
+  確認する。`test_copy_logsFalseで複製元のログが変更されずかつ複製先への書き込みが波及しない`は
+  複製直後に複製元のログ内容が変化しないこと、複製先へ`run_move()`で書き込んでも複製元の
+  ログ件数が変わらないことを確認する。
+  `test_copy_logsFalseでdeepcopy中に例外が発生しても複製元のログが復元される`は
+  `jpoke.core.battle.deepcopy`を一時的に例外を送出する関数へ差し替えたうえで
+  `battle.copy(copy_logs=False)`を呼び、`RuntimeError`が伝播したうえで複製元の
+  `event_logger`/`command_log`が同一オブジェクトのまま内容も変化していないことを確認する
+  （`finally`による復元の直接検証）。`TreeSearchPlayer`の探索結果への影響は
+  `tests/test_tree_search_framework.py`の既存テスト（`test_reseedTrueにより兄弟ノード間で
+  simの乱数系列が独立する`・`test_max_plies2でネストしたsimでも全階層のseedが重複しない`等、
+  `battle.copy(reseed=True, copy_logs=False)`を経由する経路）が引き続き通ることで確認した
+  （評価値の計算はログを参照しないため`copy_logs`の値に依存しない）。
+  `python scripts/sort_tests.py tests/test_copy.py`・`python scripts/generate_test_list.py`を
+  実行し、`python -m pytest tests/ -v`で5783件全件パス・1件skip（既存の5779件+新規テスト4件、
+  flaky testの新規発生なし）を確認した。

--- a/docs/tests/test_copy.md
+++ b/docs/tests/test_copy.md
@@ -1,7 +1,11 @@
 # test_copy
 
-テスト数: 5
+テスト数: 9
 
+- [x] copy_logsFalseでdeepcopy中に例外が発生しても複製元のログが復元される
+- [x] copy_logsFalseで複製元のログが変更されずかつ複製先への書き込みが波及しない
+- [x] copy_logsFalseで複製先のログが空になる
+- [x] copy_logsTrueで従来通りログの全履歴が引き継がれる
 - [x] mon
 - [x] terrain
 - [x] weather

--- a/src/jpoke/core/battle.py
+++ b/src/jpoke/core/battle.py
@@ -323,7 +323,7 @@ class Battle:
                     if hasattr(item, "update_reference"):
                         item.update_reference(self)
 
-    def copy(self, reseed: bool = False) -> Battle:
+    def copy(self, reseed: bool = False, copy_logs: bool = True) -> Battle:
         """Battleの複製を作成する。
 
         Args:
@@ -331,8 +331,35 @@ class Battle:
                 木探索で複数の枝が同一の乱数系列を引いて相関するのを避けたいときに使う。
                 派生シードは元のシードと派生回数から決定的に生成されるため、
                 元の乱数系列は消費されず再現性も保たれる。
+            copy_logs: Falseの場合、event_logger/command_log（対戦開始からの
+                全履歴）をdeepcopyせず、複製先に空の新規ログを持たせる
+                （複製元のログは変更されない。共有参照ではなく独立した新規の
+                空ログなので、複製先が以降 sim.step() 等で書き込んでも複製元を
+                汚染しない）。全履歴のdeepcopyはターン数に比例してコストが
+                増えるため、木探索の内部シミュレーションのようにログを
+                参照しない用途で使うとコピー負荷を削減できる。既定は
+                Trueで、従来通り履歴を引き継いだ複製を作る。
+
+        Warning:
+            copy_logs=Falseの場合、deepcopy実行中に複製元のevent_logger/command_logを
+            一時的に空へ差し替える（完了後は直ちに元へ復元する）。この間に別スレッドが
+            同じ複製元Battleのevent_logger/command_logへ読み書きすると競合しうる。
+            build_observation()と同様、このコードベースはスレッドセーフを前提として
+            いない。並列化する場合はProcessPoolExecutor等のプロセス並列を使うこと。
         """
-        new = deepcopy(self)
+        if copy_logs:
+            new = deepcopy(self)
+        else:
+            # 複製元のログを一時的に空へ差し替えてからdeepcopyすることで、
+            # 複製先には独立した空の新規ログを持たせつつ、対戦開始からの
+            # 全履歴コピーのコストを避ける。deepcopy完了後は直ちに複製元の
+            # ログを復元するため、複製元のログは変更されない。
+            saved_event_logger, saved_command_log = self.event_logger, self.command_log
+            self.event_logger, self.command_log = EventLogger(), []
+            try:
+                new = deepcopy(self)
+            finally:
+                self.event_logger, self.command_log = saved_event_logger, saved_command_log
         if reseed:
             self._reseed_count += 1
             new.seed = hash((self.seed, self._reseed_count)) & 0xFFFFFFFF

--- a/src/jpoke/players/tree_search_player.py
+++ b/src/jpoke/players/tree_search_player.py
@@ -265,7 +265,13 @@ class TreeSearchPlayer(Player):
                 # ノード数上限に達した。この my_cmd の残りの相手コマンドは
                 # 展開せず、ここまでに評価済みの分だけで worst を確定する。
                 break
-            sim = battle.copy(reseed=True)
+            # copy_logs=False: 既定のevaluate()はログを一切参照せず、内部
+            # シミュレーションのたびに対戦開始からの全履歴（event_logger/
+            # command_log）をdeepcopyするのはターン数に比例して無駄なコストが
+            # 増える。複製先には空の新規ログが渡るだけで、sim.step()以降に
+            # 追加されるログ（get_event_logs()等）は通常通り参照できる
+            # （Battle.copy()のdocstring参照）。
+            sim = battle.copy(reseed=True, copy_logs=False)
             # reseed=True により、同じ my_cmd に対する各 opp_cmd 分岐・各 my_cmd 分岐が
             # 複製元の random/decision_random の状態をそのまま共有せず、分岐ごとに
             # 派生シードで再初期化された独立の乱数系列を使う（Battle.copy() のdocstring

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -3,6 +3,7 @@ import enum
 
 import pytest
 
+import jpoke.core.battle as battle_module
 from jpoke.core.handler import Handler
 from jpoke.core.player import Player
 from jpoke.enums import Event, Interrupt
@@ -85,6 +86,98 @@ def _find_shared_mutables(old, new, path="battle", seen=None, findings=None):
                     old_vars[key], new_vars[key], f"{path}.{key}", seen, findings
                 )
     return findings
+
+
+def test_copy_logsFalseでdeepcopy中に例外が発生しても複製元のログが復元される():
+    """copy_logs=False の実装は deepcopy 実行前に複製元の event_logger/command_log を
+    一時的に空へ差し替え、完了後に finally で復元する。deepcopy 自体が例外を送出した
+    場合でも、finally によって複製元のログが元通り復元されることを確認する（r7-8回帰）。"""
+    old = t.start_battle(
+        team0=[Pokemon("ピカチュウ", move_names=["たいあたり"])],
+        team1=[Pokemon("フシギダネ")],
+        accuracy=100,
+    )
+    t.run_move(old, 0)
+    orig_event_logger = old.event_logger
+    orig_command_log = old.command_log
+    orig_logs = list(old.event_logger.logs)
+    assert orig_logs
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("deepcopy failure (test)")
+
+    real_deepcopy = battle_module.deepcopy
+    battle_module.deepcopy = boom
+    try:
+        with pytest.raises(RuntimeError):
+            old.copy(copy_logs=False)
+    finally:
+        battle_module.deepcopy = real_deepcopy
+
+    # 複製元のログは同一オブジェクトのまま、内容も変わっていない
+    assert old.event_logger is orig_event_logger
+    assert old.command_log is orig_command_log
+    assert old.event_logger.logs == orig_logs
+
+
+def test_copy_logsFalseで複製元のログが変更されずかつ複製先への書き込みが波及しない():
+    """copy_logs=False で複製した後、複製元のログ内容が変わらないこと、
+    かつ複製先へ書き込んでも複製元へ波及しないことを確認する（r7-8回帰）。"""
+    old = t.start_battle(
+        team0=[Pokemon("ピカチュウ", move_names=["たいあたり"])],
+        team1=[Pokemon("フシギダネ")],
+        accuracy=100,
+    )
+    t.run_move(old, 0)
+    old_logs_before = list(old.event_logger.logs)
+
+    new = old.copy(copy_logs=False)
+
+    # 複製直後、複製元のログは変更されていない
+    assert old.event_logger.logs == old_logs_before
+
+    # 複製先へ書き込んでも複製元は汚染されない
+    t.run_move(new, 0)
+    assert new.event_logger.logs
+    assert old.event_logger.logs == old_logs_before
+
+
+def test_copy_logsFalseで複製先のログが空になる():
+    """copy_logs=False の場合、複製先の event_logger/command_log は
+    対戦開始からの履歴を引き継がず空で始まることを確認する（r7-8回帰）。"""
+    old = t.start_battle(
+        team0=[Pokemon("ピカチュウ", move_names=["たいあたり"])],
+        team1=[Pokemon("フシギダネ")],
+        accuracy=100,
+    )
+    t.run_move(old, 0)
+    assert old.event_logger.logs
+
+    new = old.copy(copy_logs=False)
+
+    assert new.event_logger.logs == []
+    assert new.command_log == []
+    # 複製先は複製元と独立した新規のログオブジェクトを持つ（共有参照ではない）
+    assert new.event_logger is not old.event_logger
+    assert new.command_log is not old.command_log
+
+
+def test_copy_logsTrueで従来通りログの全履歴が引き継がれる():
+    """copy_logs=True（既定）の場合、event_logger/command_log の
+    対戦開始からの全履歴が複製先に引き継がれることを確認する（r7-8回帰）。"""
+    old = t.start_battle(
+        team0=[Pokemon("ピカチュウ", move_names=["たいあたり"])],
+        team1=[Pokemon("フシギダネ")],
+        accuracy=100,
+    )
+    t.run_move(old, 0)
+    assert old.event_logger.logs
+
+    new = old.copy()
+
+    assert len(new.event_logger.logs) == len(old.event_logger.logs)
+    assert new.event_logger is not old.event_logger
+    assert new.event_logger.logs == old.event_logger.logs
 
 
 def test_mon():


### PR DESCRIPTION
## Summary
- Battle.copy()がevent_logger/command_logを毎回まるごとdeepcopyし、木探索のノード数×経過ターン数に比例してコピー負荷が膨張していた問題を解消（id: r7-8、apiループ第7ラウンド）
- Battle.copy()にcopy_logs: bool = True オプションを追加（既定は従来通り）。copy_logs=Falseで複製先は独立した空ログになる
- TreeSearchPlayer._worst_case_over_opponent()でcopy_logs=Falseを使用
- 回帰テスト4件を追加（例外時のログ復元含む）

🤖 Generated with jpoke apiループ