### PR TITLE
feat: HP・ランク・みがわりHPの範囲不変条件をassertで機械検証

### DIFF
--- a/src/jpoke/handlers/volatile.py
+++ b/src/jpoke/handlers/volatile.py
@@ -1282,6 +1282,7 @@ def みがわり_block_damage(battle: Battle, ctx: EventContext, value: Any) -> 
     volatile = ctx.defender.volatiles["みがわり"]
     damage = min(volatile.hp, damage)
     volatile.hp -= damage
+    assert volatile.hp >= 0, f"みがわりHPが負値: {volatile.hp}"
 
     # みがわりに与えたダメージをコンテキストに保存しておく（後の処理で使用するため）
     ctx.substitute_damage = damage

--- a/src/jpoke/model/pokemon.py
+++ b/src/jpoke/model/pokemon.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from jpoke.types import Nature, Type, Stat, Gender, HpPolicy, \
     AilmentName, VolatileName, BoostSource, PokemonName, AbilityName, MoveName, ItemName
-from jpoke.utils.constants import STATS
+from jpoke.utils.constants import STATS, STAT_RANK_MIN, STAT_RANK_MAX
 from jpoke.utils import math as m
 from jpoke.utils import fast_copy
 from jpoke.data.pokedex import POKEDEX
@@ -905,6 +905,7 @@ class Pokemon:
         """
         hp_before = self.hp
         self.hp = max(0, min(self.max_hp, hp_before + v))
+        assert 0 <= self.hp <= self.max_hp, f"HP範囲外: hp={self.hp} max_hp={self.max_hp}"
         return self.hp - hp_before
 
     def modify_stat(self, stat: Stat, v: int) -> int:
@@ -922,6 +923,8 @@ class Pokemon:
         """
         old = self.boosts[stat]
         self.boosts[stat] = m.clamp_stats(old + v)
+        assert STAT_RANK_MIN <= self.boosts[stat] <= STAT_RANK_MAX, \
+            f"ランク範囲外: stat={stat} value={self.boosts[stat]}"
         return self.boosts[stat] - old
 
     @property


### PR DESCRIPTION
## Summary
- `Pokemon._modify_hp_raw`（HP範囲）・`Pokemon.modify_stat`（ランク範囲）・`みがわり_block_damage`（みがわりHPの非負性）の3箇所に不変条件assertを追加
- fuzz/replay_fuzz/fuzz_logの各loopは素のpython（-Oなし）で実行されるため、追加の環境変数フラグなしに自動的に有効化される
- 状態異常の相互排他は`Pokemon.ailment`が単一オブジェクト属性という型設計で構造的に保証済みのため対象外とした

## Test plan
- [x] `python -m pytest tests/ -q` で5849 passed, 0 failed, 1 skipped（挿入前と同数、偽陽性なし）