### PR TITLE
fix: フィズテストのランダム技プールから「わるあがき」を除外

### DIFF
--- a/scripts/fuzz/fuzz_common.py
+++ b/scripts/fuzz/fuzz_common.py
@@ -104,8 +104,12 @@ def random_team_spec(rng: Random, n_pokemon: int = 6, effect_bias: float = 0.0) 
     pokemon_names = list(POKEDEX.keys())
     ability_names = list(ABILITIES.keys())
     item_names = list(ITEMS.keys())
-    # "_"始まりはこんらん自傷などエンジン内部専用の技で、実際のポケモンは覚えられない
-    move_names = [name for name in MOVES if not name.startswith("_")]
+    # "_"始まりはこんらん自傷などエンジン内部専用の技で、実際のポケモンは覚えられない。
+    # 「わるあがき」もPP切れ時の自動代替技であり、実際のポケモンが技として覚えることはない
+    move_names = [
+        name for name in MOVES
+        if not name.startswith("_") and name != "わるあがき"
+    ]
 
     inducing_abilities: list[str] = []
     inducing_items: list[str] = []


### PR DESCRIPTION
## Summary
- わるあがきはPP切れ時の自動代替技であり、実際のポケモンは技として覚えられないが、`scripts/fuzz/fuzz_common.py`のランダム技プール生成が「_」始まりの内部専用技のみを除外していたため、わるあがきが通常技として混入し得た
- seed=629のフィズバッチでカメテテがPP切れでもないのにわるあがきを通常技として選択・使用しているログを発見（`まとわりつく`のPPが残存していたにもかかわらず、わるあがきが技コマンド候補に現れていた）
- `move_names`のフィルタに `name != "わるあがき"` を追加して除外

## Test plan
- [x] `python -m pytest tests/ -v` 全件通過
- [x] `python -m pytest tests/test_replay_fuzz.py tests/test_fuzz_regressions.py -v` 通過（リプレイ整合性はチーム構成に依存しないテスト設計のため、技プール変更の影響を受けない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)