### PR TITLE
feat: Pokemonインスタンスからlearnsets.jsonを参照できるようにする

### DIFF
--- a/src/jpoke/data/learnset.py
+++ b/src/jpoke/data/learnset.py
@@ -1,8 +1,7 @@
 import json
 from importlib import resources
-from jpoke.data.models import PokemonData
-from jpoke.data.learnset import LEARNSETS
-from jpoke.types import PokemonName
+
+from jpoke.types import MoveName, PokemonName
 
 
 def resource_path(*path_parts: str) -> str:
@@ -13,10 +12,10 @@ def resource_path(*path_parts: str) -> str:
     return str(resources.files("jpoke").joinpath(*path_parts))
 
 
-file = resource_path('data', 'ps-champ-ja', "pokedex.json")
+file = resource_path('data', 'ps-champ-ja', "learnsets.json")
 with open(file, encoding='utf-8') as f:
     data = json.load(f)
 
-POKEDEX: dict[PokemonName, PokemonData] = {
-    name: PokemonData(name, entry, LEARNSETS.get(name, frozenset())) for name, entry in data.items()
+LEARNSETS: dict[PokemonName, frozenset[MoveName]] = {
+    name: frozenset(moves) for name, moves in data.items()
 }

--- a/src/jpoke/data/models.py
+++ b/src/jpoke/data/models.py
@@ -11,7 +11,7 @@ from jpoke.types import AbilityFlag, Type, MoveCategory, MoveTarget, MoveFlag, P
 
 
 class PokemonData:
-    def __init__(self, name, data) -> None:
+    def __init__(self, name, data, learnset: frozenset[MoveName] = frozenset()) -> None:
         self.name: PokemonName = name
         self.pre_evolution: PokemonName | Literal[""] = data.get("prevo", "")
         self.weight: float = data["weight"]
@@ -19,6 +19,7 @@ class PokemonData:
         self.abilities: list[AbilityName] = list(data["abilities"])
         stats = data["baseStats"]
         self.base: list[int] = [stats["hp"], stats["atk"], stats["def"], stats["spa"], stats["spd"], stats["spe"]]
+        self.learnset: frozenset[MoveName] = learnset
 
         if not self.abilities:
             self.abilities = [""]

--- a/src/jpoke/model/pokemon.py
+++ b/src/jpoke/model/pokemon.py
@@ -521,6 +521,26 @@ class Pokemon:
         return type_ in self.types
 
     @property
+    def learnset(self) -> frozenset[MoveName]:
+        """覚えられる技名の集合を取得する。
+
+        Returns:
+            覚えられる技名の集合（ps-champ-ja由来のスナップショット）
+        """
+        return self.data.learnset
+
+    def can_learn(self, move_name: MoveName) -> bool:
+        """指定された技を覚えられるか判定する。
+
+        Args:
+            move_name: 技名
+
+        Returns:
+            覚えられる場合True
+        """
+        return move_name in self.learnset
+
+    @property
     def alive(self) -> bool:
         """ポケモンが生存しているかどうかを取得する。
 


### PR DESCRIPTION
## Summary
- `data/learnset.py` を新設し、`learnsets.json` から `LEARNSETS: dict[PokemonName, frozenset[MoveName]]` を構築
- `PokemonData` に `learnset` フィールドを追加し、`pokedex.py` の `POKEDEX` 構築時に注入
- `Pokemon.learnset` プロパティ / `Pokemon.can_learn(move_name)` を追加し、インスタンスから覚える技一覧を参照可能にする

## Test plan
- [x] `python -m pytest tests/ -q` 5955 passed, 0 failed, 1 skipped
- [x] `Pokemon('フシギダネ').can_learn('つるぎのまい')` などで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)