### PR TITLE
refactor: 瀕死ガードをHandlerの宣言的フィールドで一元化

### DIFF
--- a/src/jpoke/core/ability_manager.py
+++ b/src/jpoke/core/ability_manager.py
@@ -170,7 +170,6 @@ class AbilityManager:
             self._events.emit(
                 Event.ON_ABILITY_ENABLED,
                 EventContext(source=mon),
-                skip_if_subject_fainted=True,
             )
             return True
         return False

--- a/src/jpoke/core/event_manager.py
+++ b/src/jpoke/core/event_manager.py
@@ -108,8 +108,7 @@ class EventManager:
              event: Event | DomainEvent,
              ctx: BaseContext | None = None,
              value: Any = None,
-             stop_if_winner_determined: bool = False,
-             skip_if_subject_fainted: bool = False) -> Any:
+             stop_if_winner_determined: bool = False) -> Any:
         """イベントを発火し、登録されたハンドラを実行する。
 
         優先度とポケモンの素早さに基づいてハンドラを順次実行します。
@@ -126,20 +125,6 @@ class EventManager:
                 継続ダメージ）を素早さ順にまとめて処理するイベントで、
                 先に処理された個体の瀕死により決着した後、決着に無関係な
                 他個体のハンドラが実行され続けるのを防ぐために使う
-            skip_if_subject_fainted: Trueの場合、ハンドラの
-                subject_spec が指すポケモン（例: "source:self" なら
-                context.source）が既に瀕死の場合、そのハンドラの実行を
-                スキップする。Event.ON_SWITCH_IN のように、入場した
-                ポケモン自身が先に処理された設置技ダメージ等
-                （まきびし・ステルスロック等）で瀕死になった場合、
-                同じポケモン自身のその後の入場効果（天候特性・
-                エレキメイカー等の入場特性）を発動させないために使う
-                （一次情報: docs/spec/abilities/エレキメイカー.md
-                「場に出た直後に設置技のダメージでひんしになった場合、
-                エレキメイカーは発動しない」）。ON_DAMAGE_HIT のほろびの
-                ボディ等、瀕死になった当のポケモン自身の効果が発動する
-                べきイベントもあるため、既定は False とし呼び出し側で
-                イベントごとに明示的に指定する
 
         Returns:
             Any: 全ハンドラ実行後の最終値
@@ -156,14 +141,9 @@ class EventManager:
             context = ctx if ctx else self._build_context(rh)
 
             # ハンドラが現在のコンテキストで有効かどうかをチェックする
+            # （subject_spec が指すポケモンが既に瀕死の場合のスキップ判定を含む）
             if not self._check_handler_validity(rh, context):
                 continue
-
-            # subject_spec が指すポケモンが既に瀕死ならスキップする
-            if skip_if_subject_fainted:
-                role_mon = context.resolve_role(self.battle, rh.handler.subject_spec)
-                if role_mon is not None and role_mon.fainted:
-                    continue
 
             result = rh.handler.func(self.battle, context, value)
 
@@ -227,6 +207,14 @@ class EventManager:
         ):
             # print(f"Context mismatch: Handler {rh.handler.func} skipped")
             return False
+
+        # subject_spec が指すポケモンが既に瀕死ならスキップする。
+        # Event.ON_MOVE_KO のように、瀕死になった当のポケモン自身の効果が
+        # 発動すべきハンドラは Handler.allow_fainted_subject=True で明示的に除外する。
+        if not rh.handler.allow_fainted_subject:
+            role_mon = ctx.resolve_role(self.battle, rh.handler.subject_spec)
+            if role_mon is not None and role_mon.fainted:
+                return False
 
         # ハンドラの発生源が無効化されている場合はスキップ
         match rh.handler.source:

--- a/src/jpoke/core/handler.py
+++ b/src/jpoke/core/handler.py
@@ -48,6 +48,7 @@ class Handler:
     once: bool = False
     skip_subject_check: bool = False  # ハンドラの主体の照合をスキップするか
     ignored_disable_reasons: frozenset[str] = field(default_factory=frozenset)  # 無効化理由のうち無視するもの（例: とくせいガードはぶきように影響されない）
+    allow_fainted_subject: bool = False  # 主体（subject_spec解決先）が瀕死でも発動を許すか（例: ON_MOVE_KOで瀕死になった当人自身が発動する効果）
     role: ContextRole = field(init=False)
     side: Side = field(init=False)
 

--- a/src/jpoke/core/switch_manager.py
+++ b/src/jpoke/core/switch_manager.py
@@ -123,7 +123,6 @@ class SwitchManager:
         self._events.emit(
             Event.ON_SWITCH_IN,
             EventContext(source=mon),
-            skip_if_subject_fainted=True,
         )
 
         self._resolve_ejectpack_after_switch()
@@ -195,7 +194,7 @@ class SwitchManager:
             self._switch_in(state, new)
 
         # ポケモンが場に出たときの処理は、両者の交代が完了した後に行う
-        self._events.emit(Event.ON_SWITCH_IN, skip_if_subject_fainted=True)
+        self._events.emit(Event.ON_SWITCH_IN)
 
         # だっしゅつパックによる割り込みフラグをフェーズに合わせて設定
         self.override_ejectpack_interrupt(Interrupt.EJECTPACK_ON_START)
@@ -254,7 +253,6 @@ class SwitchManager:
                 self._events.emit(
                     Event.ON_SWITCH_IN,
                     EventContext(source=mon),
-                    skip_if_subject_fainted=True,
                 )
 
         # 上記の着地処理（例: ねばねばネットによるすばやさ低下）でだっしゅつパックの

--- a/src/jpoke/data/ability.py
+++ b/src/jpoke/data/ability.py
@@ -249,10 +249,12 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_CHECK_FLOATING: h.AbilityHandler(
                 h.ふゆう_float,
                 subject_spec="source:self",
+                allow_fainted_subject=True,  # 技のダメージ計算中に使用者が瀕死になっても浮遊判定は維持する
             ),
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.ビーストブースト_boost_best_stat_on_ko,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             ),
         }
     ),
@@ -895,6 +897,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.くろのいななき_boost,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             )
         }
     ),
@@ -1041,6 +1044,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
                 h.さまようたましい_swap_ability_on_contact,
                 subject_spec="defender:self",
                 priority=20,
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する
             ),
         }
     ),
@@ -1049,6 +1053,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_DAMAGE_HIT: h.AbilityHandler(
                 h.さめはだ_chip_contact_attacker,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する
             )
         }
     ),
@@ -1153,6 +1158,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.しろのいななき_boost,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             )
         }
     ),
@@ -1222,6 +1228,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.しろのいななき_boost,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             )
         }
     ),
@@ -1294,6 +1301,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.じんばいったい_boost,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             ),
         }
     ),
@@ -1521,6 +1529,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_HP_CHANGED: h.AbilityHandler(
                 h.スワームチェンジ_revert_form_on_faint,
                 subject_spec="target:self",
+                allow_fainted_subject=True,  # 瀕死になったこと自体がパーフェクトフォルム解除の発動条件
             ),
         }
     ),
@@ -1611,6 +1620,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.ソウルハート_boost_spa_on_ko,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             ),
             Event.ON_HP_CHANGED: h.AbilityHandler(
                 h.ソウルハート_boost_spa_on_faint,
@@ -1984,6 +1994,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.とびだすなかみ_retaliate_on_ko,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 自身が瀕死になった(ON_MOVE_KO)ことがこの効果の発動条件
             ),
         }
     ),
@@ -2009,6 +2020,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
                 h.とれないにおい_overwrite_attacker_ability,
                 subject_spec="defender:self",
                 priority=20,
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する（ミイラ等と同種の効果）
             ),
         }
     ),
@@ -2196,6 +2208,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_DAMAGE_HIT: h.AbilityHandler(
                 h.ぬめぬめ_lower_spd_on_contact,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する
             )
         }
     ),
@@ -2391,6 +2404,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_SWITCH_OUT: h.AbilityHandler(
                 h.はらぺこスイッチ_on_switch_out,
                 subject_spec="source:self",
+                allow_fainted_subject=True,  # 瀕死交代でON_SWITCH_OUTが発火した場合もフォルム状態更新が必要
             ),
             Event.ON_TURN_END: h.AbilityHandler(
                 h.はらぺこスイッチ_on_turn_end,
@@ -2650,6 +2664,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.ビーストブースト_boost_best_stat_on_ko,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             )
         }
     ),
@@ -2847,6 +2862,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_CHECK_FLOATING: h.AbilityHandler(
                 h.ふゆう_float,
                 subject_spec="source:self",
+                allow_fainted_subject=True,  # 技のダメージ計算中に使用者が瀕死になっても浮遊判定は維持する
             )
         }
     ),
@@ -3023,6 +3039,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
                 h.ほろびのボディ_apply_perish_song_on_contact,
                 subject_spec="defender:self",
                 priority=20,
+                allow_fainted_subject=True,  # 自身が接触技でひんしになった場合でも発動する
             )
         }
     ),
@@ -3196,6 +3213,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
                 h.ミイラ_overwrite_attacker_ability,
                 subject_spec="defender:self",
                 priority=20,
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する
             ),
         }
     ),
@@ -3422,6 +3440,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_MOVE_KO: h.AbilityHandler(
                 h.ゆうばく_damage_attacker_on_ko,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 自身が瀕死になった(ON_MOVE_KO)ことがこの効果の発動条件
             )
         }
     ),
@@ -3616,6 +3635,7 @@ ABILITIES: dict[AbilityName, AbilityData] = {
             Event.ON_DAMAGE_HIT: h.AbilityHandler(
                 h.わたげ_lower_spd_on_hit,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 自身が直接攻撃でひんしになった場合でも発動する
             )
         }
     ),

--- a/src/jpoke/data/ailment.py
+++ b/src/jpoke/data/ailment.py
@@ -96,6 +96,7 @@ AILMENTS: dict[str, AilmentData] = {
             Event.ON_DAMAGE_HIT: h.AilmentHandler(
                 h.こおり_cure_by_thaw_move,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 解凍対象がほのお技でひんしになった場合でも解凍自体は発生する
             )
         }
     ),

--- a/src/jpoke/data/field/global_field.py
+++ b/src/jpoke/data/field/global_field.py
@@ -21,6 +21,7 @@ GLOBAL_FIELD: dict[str, FieldData] = {
                 h.じゅうりょく_tick,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -34,6 +35,7 @@ GLOBAL_FIELD: dict[str, FieldData] = {
                 h.トリックルーム_tick,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -47,6 +49,7 @@ GLOBAL_FIELD: dict[str, FieldData] = {
                 h.フェアリーロック_tick,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -68,6 +71,7 @@ GLOBAL_FIELD: dict[str, FieldData] = {
                 h.マジックルーム_tick,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -81,6 +85,7 @@ GLOBAL_FIELD: dict[str, FieldData] = {
                 h.ワンダールーム_tick,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),

--- a/src/jpoke/data/field/side_field.py
+++ b/src/jpoke/data/field/side_field.py
@@ -13,6 +13,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.リフレクター_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -26,6 +27,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.ひかりのかべ_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -39,6 +41,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.オーロラベール_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -56,6 +59,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.しんぴのまもり_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -70,6 +74,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.しろいきり_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -101,6 +106,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.おいかぜ_tick,
                 subject_spec="source:self",
                 priority=130,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -110,6 +116,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.ねがいごと_tick,
                 subject_spec="source:self",
                 priority=50,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
             Event.ON_FIELD_DEACTIVATE: h.FieldHandler(
                 h.ねがいごと_heal,
@@ -123,6 +130,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.みらいよち_tick,
                 subject_spec="source:self",
                 priority=40,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
             Event.ON_FIELD_DEACTIVATE: h.FieldHandler(
                 h.みらいよち_damage,
@@ -136,6 +144,7 @@ SIDE_FIELD: dict[str, FieldData] = {
                 h.はめつのねがい_tick,
                 subject_spec="source:self",
                 priority=40,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
             Event.ON_FIELD_DEACTIVATE: h.FieldHandler(
                 h.はめつのねがい_damage,

--- a/src/jpoke/data/field/terrain.py
+++ b/src/jpoke/data/field/terrain.py
@@ -23,6 +23,7 @@ TERRAIN: dict[str, FieldData] = {
                 h.tick_terrain,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -46,6 +47,7 @@ TERRAIN: dict[str, FieldData] = {
                     h.tick_terrain,
                     subject_spec="source:self",
                     priority=140,
+                    allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
                 ),
             ]
         },
@@ -68,6 +70,7 @@ TERRAIN: dict[str, FieldData] = {
                 h.tick_terrain,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -89,6 +92,7 @@ TERRAIN: dict[str, FieldData] = {
                 h.tick_terrain,
                 subject_spec="source:self",
                 priority=140,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),

--- a/src/jpoke/data/field/weather.py
+++ b/src/jpoke/data/field/weather.py
@@ -31,6 +31,7 @@ WEATHER: dict[str, FieldData] = {
                 h.tick_weather,
                 subject_spec="source:self",
                 priority=10,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -44,6 +45,7 @@ WEATHER: dict[str, FieldData] = {
                 h.tick_weather,
                 subject_spec="source:self",
                 priority=10,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),
@@ -58,6 +60,7 @@ WEATHER: dict[str, FieldData] = {
                     h.tick_weather,
                     subject_spec="source:self",
                     priority=10,
+                    allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
                 ),
                 h.FieldHandler(
                     h.すなあらし_turn_end,
@@ -80,6 +83,7 @@ WEATHER: dict[str, FieldData] = {
                 h.tick_weather,
                 subject_spec="source:self",
                 priority=10,
+                allow_fainted_subject=True,  # フィールドcountdownはsource(occupant)の生死に関わらず毎ターン進行させる
             ),
         },
     ),

--- a/src/jpoke/data/item.py
+++ b/src/jpoke/data/item.py
@@ -1661,6 +1661,7 @@ ITEMS: dict[ItemName, ItemData] = {
             Event.ON_PP_CONSUMED: h.ItemHandler(
                 h.ヒメリのみ_restore_pp,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # ぶきみなじゅもん等でPPが0になった際に自身が瀕死でも発動する
             ),
             Event.ON_SWITCH_IN: h.ItemHandler(
                 h.ヒメリのみ_restore_pp_if_any_move_empty,

--- a/src/jpoke/data/moves/move_a.py
+++ b/src/jpoke/data/moves/move_a.py
@@ -68,6 +68,7 @@ MOVES_A: dict[MoveName, MoveData] = {
                 ha.アイススピナー_clear_terrain,
                 subject_spec="attacker:self",
                 priority=180,
+                allow_fainted_subject=False,  # いのちのたまの反動等で自身がひんしになった場合はフィールドを解除しない
             ),
         }
     ),

--- a/src/jpoke/data/moves/move_ma.py
+++ b/src/jpoke/data/moves/move_ma.py
@@ -113,8 +113,8 @@ MOVES_MA: dict[MoveName, MoveData] = {
     "まねっこ": MoveData(
         flags={"non_negoto", "non_copycat"},  # まねっこ自身はまねっこでコピー不可
         handlers={
-            Event.ON_BEFORE_APPLY_MOVE: h.MoveHandler(hs.まねっこ_can_use),
-            Event.ON_STATUS_HIT: h.MoveHandler(hs.まねっこ_execute),
+            Event.ON_BEFORE_APPLY_MOVE: h.MoveHandler(hs.まねっこ_can_use, allow_fainted_subject=True),
+            Event.ON_STATUS_HIT: h.MoveHandler(hs.まねっこ_execute, allow_fainted_subject=True),
         },
     ),
     "まほうのこな": MoveData(
@@ -215,6 +215,7 @@ MOVES_MA: dict[MoveName, MoveData] = {
             Event.ON_CALC_POWER_MODIFIER: h.MoveHandler(
                 ha.ミストバースト_calc_power,
                 subject_spec="attacker:self",
+                allow_fainted_subject=True,  # ON_PAY_HPのHP全消費で使用者が先に瀕死になっても威力計算は行う
             ),
         }
     ),

--- a/src/jpoke/data/moves/move_ta.py
+++ b/src/jpoke/data/moves/move_ta.py
@@ -850,6 +850,7 @@ MOVES_TA: dict[MoveName, MoveData] = {
             Event.ON_MOVE_KO: h.MoveHandler(
                 ha.とどめばり_boost_attacker_atk,
                 priority=50,
+                allow_fainted_subject=True,  # HPコスト技等で自身が瀕死になっても、撃破時(ON_MOVE_KO)の効果は発動する
             )
         }
     ),

--- a/src/jpoke/data/volatile.py
+++ b/src/jpoke/data/volatile.py
@@ -141,7 +141,8 @@ VOLATILES: dict[str, VolatileData] = {
             Event.ON_MOVE_KO: h.VolatileHandler(
                 h.おんねん_deplete_attacking_move_pp,
                 subject_spec="defender:self",
-                priority=10
+                priority=10,
+                allow_fainted_subject=True,  # 自身が瀕死になった(ON_MOVE_KO)ことがこの効果の発動条件
             ),
         }
     ),
@@ -215,6 +216,7 @@ VOLATILES: dict[str, VolatileData] = {
             Event.ON_DAMAGE_HIT: h.VolatileHandler(
                 h.くちばしキャノン_burn_on_contact,
                 subject_spec="defender:self",
+                allow_fainted_subject=True,  # 使用者が接触技でひんしになった場合でも攻撃者をやけどにする
             ),
             Event.ON_TRY_ACTION: h.VolatileHandler(
                 h.くちばしキャノン_end_heating,
@@ -837,7 +839,8 @@ VOLATILES: dict[str, VolatileData] = {
             Event.ON_MOVE_KO: h.VolatileHandler(
                 h.みちづれ_faint,
                 subject_spec="defender:self",
-                priority=30
+                priority=30,
+                allow_fainted_subject=True,  # 自身が瀕死になった(ON_MOVE_KO)ことがこの効果の発動条件
             ),
             Event.ON_TRY_ACTION: h.VolatileHandler(
                 h.みちづれ_remove,

--- a/src/jpoke/handlers/ability.py
+++ b/src/jpoke/handlers/ability.py
@@ -93,7 +93,8 @@ class AbilityHandler(Handler):
                  subject_spec: RoleSpec,
                  priority: int = 100,
                  once: bool = False,
-                 ignored_disable_reasons: frozenset[str] = frozenset()) -> None:
+                 ignored_disable_reasons: frozenset[str] = frozenset(),
+                 allow_fainted_subject: bool = False) -> None:
         super().__init__(
             func=func,
             source="ability",
@@ -101,6 +102,7 @@ class AbilityHandler(Handler):
             priority=priority,
             once=once,
             ignored_disable_reasons=ignored_disable_reasons,
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 def announce_ability_triggered(battle: Battle,
@@ -450,9 +452,6 @@ def アイスフェイス_restore_on_switch_in(battle: Battle, ctx: EventContext
 def アイスボディ_heal(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """アイスボディ特性: ゆき中にターン終了時に最大HPの1/16を回復する。"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if (
         battle.weather.name == "ゆき"
         and battle.modify_hp(mon, r=1/16)
@@ -539,9 +538,6 @@ def あめうけざら_heal(battle: Battle, ctx: EventContext, value: Any) -> Ha
     ばんのうがさを持つ場合は雨の恩恵を受けない。
     """
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if not battle.weather_for(mon).rainy:
         return HandlerReturn(value=value)
 
@@ -629,8 +625,6 @@ def いかりのつぼ_max_atk_on_crit(battle: Battle, ctx: AttackContext, value
     if not battle.move_executor.critical:
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     diff = 6 - mon.boosts["atk"]
     if diff > 0 and battle.modify_stats(mon, {"atk": diff}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
@@ -1112,9 +1106,6 @@ def かんそうはだ_change_hp_by_weather(battle: Battle, ctx: EventContext, v
     ばんのうがさを持つ場合は晴れダメージ・雨回復を受けない。
     """
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     weather = battle.weather_for(mon)
 
     # あめ中は最大HPの1/8回復
@@ -1356,14 +1347,7 @@ def きんしのちから_restore_foe_ability(battle: Battle, ctx: AttackContext
 
 
 def きんちょうかん_check_nervous(battle: Battle, ctx: EventContext, value: bool) -> HandlerReturn:
-    """きんちょうかん特性: 相手のきのみ使用を禁止する。
-
-    自身がひんしになった瞬間に効果が失われるため、場に留まっている（生存している）
-    ことを確認する。
-    """
-    assert ctx.source is not None
-    if battle.foe(ctx.source).fainted:
-        return HandlerReturn(value=value)
+    """きんちょうかん特性: 相手のきのみ使用を禁止する。"""
     return HandlerReturn(value=True)
 
 
@@ -1497,8 +1481,6 @@ def くだけるよろい_drop_B_boost_S(battle: Battle, ctx: AttackContext, val
     if ctx.move.category != "physical":
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     battle.modify_stats(mon, {"def": -1}, source=mon)
     if battle.modify_stats(mon, {"spe": +2}, source=mon):
         _announce_ability_triggered(battle, mon)
@@ -1626,9 +1608,6 @@ def サイコメイカー_activate_terrain(battle: Battle, ctx: EventContext, va
 def さいせいりょく_heal_on_withdraw(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """さいせいりょく特性: 交代で引っ込んだとき最大HPの1/3を回復する（かいふくふうじ無効）。"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（瀕死交代でON_SWITCH_OUTが発火した場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_hp(mon, r=1/3, reason="bench_heal"):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -1867,8 +1846,6 @@ def じきゅうりょく_boost_B_on_hit(battle: Battle, ctx: AttackContext, val
     if ctx.substitute_damage:
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_stats(mon, {"def": +1}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -1891,8 +1868,6 @@ def じょうききかん_max_boost_speed(battle: Battle, ctx: AttackContext, va
     if ctx.move.type not in ("みず", "ほのお"):
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_stats(mon, {"spe": +6}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -2223,8 +2198,6 @@ def せいぎのこころ_boost_atk_on_dark(battle: Battle, ctx: AttackContext, 
     if ctx.move.type != "あく":
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_stats(mon, {"atk": +1}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -2954,8 +2927,6 @@ def ねつこうかん_boost_atk_on_fire(battle: Battle, ctx: AttackContext, val
     """
     if ctx.move.type != "ほのお":
         return HandlerReturn(value=value)
-    if ctx.defender.fainted:
-        return HandlerReturn(value=value)
 
     changed = battle.modify_stats(ctx.defender, {"atk": +1}, source=ctx.attacker)
     if not changed:
@@ -3450,8 +3421,6 @@ def びびり_boost_spd_on_fear_move(battle: Battle, ctx: AttackContext, value: 
     if ctx.move.type not in ("あく", "ゴースト", "むし"):
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_stats(mon, {"spe": +1}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -4199,8 +4168,6 @@ def みずがため_boost_B_on_water(battle: Battle, ctx: AttackContext, value: 
     if ctx.move.type != "みず":
         return HandlerReturn(value=value)
     mon = ctx.defender
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_stats(mon, {"def": +2}, source=ctx.attacker):
         _announce_ability_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -4258,9 +4225,6 @@ def ミラーアーマー_reflect_stat_drop(battle: Battle, ctx: EventContext, v
 def ムラっけ_boost_stats(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """ムラっけ特性: ターン終了時に1能力+2、別の1能力-1する。"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     stats: tuple[Stat, ...] = ("atk", "def", "spa", "spd", "spe")
     raised_stat: Stat | None = None
     changed = False

--- a/src/jpoke/handlers/ailment.py
+++ b/src/jpoke/handlers/ailment.py
@@ -13,12 +13,14 @@ class AilmentHandler(Handler):
     def __init__(self,
                  func: Callable,
                  subject_spec: RoleSpec,
-                 priority: int = 100):
+                 priority: int = 100,
+                 allow_fainted_subject: bool = False):
         super().__init__(
             func=func,
             source="ailment",
             subject_spec=subject_spec,
             priority=priority,
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 
@@ -96,10 +98,6 @@ def こおり_cure_by_thaw_move(battle: Battle, ctx: AttackContext, value: Any) 
 def どく_damage(battle: Battle, ctx: EventContext, value: Any):
     """どく状態によるターン終了時ダメージ（最大HPの1/8、最小1）。"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む。
-    # ポイズンヒール特性はこのダメージを回復に変換するため、瀕死ポケモンの蘇生を防ぐ必要がある）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     damage = max(1, mon.max_hp // 8)
     battle.modify_hp(mon, v=-damage, reason="poison")
     return HandlerReturn(value=value)
@@ -170,10 +168,6 @@ def もうどく_damage(battle: Battle, ctx: EventContext, value: Any):
     経過ターン数の上限は15（最大ダメージは最大HP × 15/16）。
     """
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む。
-    # ポイズンヒール特性はこのダメージを回復に変換するため、瀕死ポケモンの蘇生を防ぐ必要がある）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     battle.ailment_manager.tick(mon)
     turns = min(15, mon.ailment.elapsed_turns)
     damage = max(1, mon.max_hp * turns // 16)

--- a/src/jpoke/handlers/field.py
+++ b/src/jpoke/handlers/field.py
@@ -14,12 +14,14 @@ class FieldHandler(Handler):
     def __init__(self,
                  func: Callable,
                  subject_spec: RoleSpec,
-                 priority: int = 100):
+                 priority: int = 100,
+                 allow_fainted_subject: bool = False):
         super().__init__(
             func=func,
             source="field",
             subject_spec=subject_spec,
             priority=priority,
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 def tick_weather(battle: Battle, ctx: EventContext, value: Any):
@@ -182,9 +184,6 @@ def グラスフィールド_boost_move_priority(battle: Battle, ctx: AttackCont
 
 def グラスフィールド_heal(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """グラスフィールドのターン終了時回復"""
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if ctx.source.fainted:
-        return HandlerReturn(value=value)
     if not battle.query.is_floating(ctx.source):
         battle.modify_hp(ctx.source, r=1/16)
     return HandlerReturn(value=value)
@@ -396,9 +395,6 @@ def どくびし_apply_poison(battle: Battle, ctx: EventContext, value: Any) -> 
 
 def ねがいごと_heal(battle: Battle, ctx: EventContext, value: Field) -> HandlerReturn:
     """ねがいごとのターン終了時HP回復"""
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if ctx.source.fainted:
-        return HandlerReturn(value=value)
     battle.modify_hp(ctx.source, v=value.heal)
     return HandlerReturn(value=value)
 

--- a/src/jpoke/handlers/item.py
+++ b/src/jpoke/handlers/item.py
@@ -35,7 +35,8 @@ class ItemHandler(Handler):
                  subject_spec: RoleSpec,
                  priority: int = 100,
                  once: bool = False,
-                 ignored_disable_reasons: frozenset[str] = frozenset()) -> None:
+                 ignored_disable_reasons: frozenset[str] = frozenset(),
+                 allow_fainted_subject: bool = False) -> None:
         super().__init__(
             func=func,
             source="item",
@@ -43,6 +44,7 @@ class ItemHandler(Handler):
             priority=priority,
             once=once,
             ignored_disable_reasons=ignored_disable_reasons,
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 def announce_item_triggered(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
@@ -226,9 +228,6 @@ def _heal_berry(battle: Battle,
                 confuse_natures: tuple[str, ...] | None = None) -> HandlerReturn:
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない（設置技等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     denominator = _gluttony_denominator(mon, denominator)
     # value >= mon.max_hp はほおばる等による強制発動（HP閾値チェックを無視する）
     forced = value >= mon.max_hp
@@ -303,9 +302,6 @@ def _boost_on_quarter_hp(battle: Battle,
     """
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     forced = value >= mon.max_hp
     denominator = _gluttony_denominator(mon, 4)
     if not forced:
@@ -427,9 +423,6 @@ def _boost_stat_on_type_hit(battle: Battle,
                             stats: dict[Stat, int]) -> HandlerReturn:
     mon = ctx.defender
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if ctx.move.type == type_:
         changes = battle.modify_stats(mon, stats)
         if changes:  # ランク上限などで不発の場合は消費しない
@@ -558,9 +551,6 @@ def イバンのみ_set_priority_flag(battle: Battle, ctx: EventContext, value: 
     """
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if ctx.hp_change_reason == "self_attack":
         return HandlerReturn(value=value)
     denominator = _gluttony_denominator(mon, 4)
@@ -921,9 +911,6 @@ def くろいてっきゅう_negate_floating(_battle: Battle, _ctx: EventContext
 def くろいヘドロ_heal_or_damage(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     mon = ctx.source
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     r = 1/16 if mon.has_type("どく") else -1/8
     if battle.modify_hp(mon, r=r):
         _announce_item_triggered(battle, mon)
@@ -1054,9 +1041,6 @@ def サンのみ_apply_focus_energy(battle: Battle, ctx: EventContext, value: An
     """
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     denominator = _gluttony_denominator(mon, 4)
     if mon.hp * denominator <= mon.max_hp or value >= mon.max_hp:
         if battle.volatile_manager.apply(mon, "きゅうしょアップ", count=2):
@@ -1146,9 +1130,6 @@ def じゃくてんほけん_boost_on_super_effective(battle: Battle, ctx: Attac
     """
     mon = ctx.defender
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if ctx.move.has_flag("fixed_damage"):
         return HandlerReturn(value=value)
     if battle.query.is_super_effective(ctx):
@@ -1177,9 +1158,6 @@ def スターのみ_random_boost(battle: Battle, ctx: EventContext, value: Any) 
     """
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     forced = value >= mon.max_hp
     denominator = _gluttony_denominator(mon, 4)
     if not forced:
@@ -1243,9 +1221,6 @@ def たつじんのおび_boost_super_effective(battle: Battle, ctx: AttackConte
 def たべのこし_heal(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """たべのこし: ターン終了時HP回復"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if battle.modify_hp(mon, r=1/16):
         _announce_item_triggered(battle, mon)
     return HandlerReturn(value=value)
@@ -1463,9 +1438,6 @@ def ナゾのみ_heal_on_super_effective(battle: Battle, ctx: AttackContext, val
     """
     mon = ctx.defender
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if ctx.move.has_flag("fixed_damage"):
         return HandlerReturn(value=value)
     # 相手のきんちょうかん・じんばいったいの影響下では発動しない
@@ -1929,9 +1901,6 @@ def ミクルのみ_set_accuracy_flag(battle: Battle, ctx: EventContext, value: 
     """
     mon = ctx.target
     assert mon is not None
-    # ひんし(HP0)になったときは発動しない
-    if mon.fainted:
-        return HandlerReturn(value=value)
     if ctx.hp_change_reason == "self_attack":
         return HandlerReturn(value=value)
     denominator = _gluttony_denominator(mon, 4)

--- a/src/jpoke/handlers/move.py
+++ b/src/jpoke/handlers/move.py
@@ -23,13 +23,21 @@ class MoveHandler(Handler):
     def __init__(self,
                  func: Callable,
                  subject_spec: RoleSpec = "attacker:self",
-                 priority: int = 100):
+                 priority: int = 100,
+                 allow_fainted_subject: bool = True):
         """MoveHandlerを初期化する。
 
         Args:
             func: イベント発生時に呼ばれる処理関数
             subject_spec: ハンドラの対象を指定するロール
             priority: ハンドラの優先度
+            allow_fainted_subject: 主体（subject_spec解決先）が瀕死でも発動を許すか。
+                技ハンドラは「技が現在進行中である」という前提のみで動く技実行フロー
+                固有のロジック（HPコスト支払いで使用者が先に瀕死になる場合や、
+                対象がすでに瀕死かの判定自体を行うハンドラ等）が多いため、
+                他のHandlerサブクラスと異なり既定でTrueとする。逆に「使用者が
+                瀕死になったら以降の効果を打ち切る」個別の技（アイススピナー等）は
+                登録時に明示的にFalseを指定する。
         """
         super().__init__(
             func=func,
@@ -37,6 +45,7 @@ class MoveHandler(Handler):
             subject_spec=subject_spec,
             priority=priority,
             skip_subject_check=True,  # 技ハンドラはコンテキストの攻守を直接参照するため、主体の照合をスキップする
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 

--- a/src/jpoke/handlers/move_attack.py
+++ b/src/jpoke/handlers/move_attack.py
@@ -117,8 +117,6 @@ def アイススピナー_clear_terrain(battle: Battle, ctx: AttackContext, valu
     技の仕様節「自分のいのちのたまの反動で使用者がひんしになったときはフィールドを
     解除できない」）。
     """
-    if ctx.attacker.fainted:
-        return HandlerReturn(value=value)
     battle.terrain_manager.remove()
     return HandlerReturn(value=value)
 

--- a/src/jpoke/handlers/volatile.py
+++ b/src/jpoke/handlers/volatile.py
@@ -29,13 +29,15 @@ class VolatileHandler(Handler):
                  func: Callable,
                  subject_spec: RoleSpec = "source:self",
                  priority: int = 100,
-                 once: bool = False):
+                 once: bool = False,
+                 allow_fainted_subject: bool = False):
         super().__init__(
             func=func,
             source="volatile",
             subject_spec=subject_spec,
             priority=priority,
-            once=once
+            once=once,
+            allow_fainted_subject=allow_fainted_subject,
         )
 
 def check_trapped_not_ghost(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
@@ -149,9 +151,6 @@ def restrict_commands(battle: Battle,
 def アクアリング_self_heal(battle: Battle, ctx: EventContext, value: Any) -> HandlerReturn:
     """アクアリング状態のターン終了時回復（最大HPの1/16、最小1）。"""
     mon = ctx.source
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if mon.fainted:
-        return HandlerReturn(value=value)
     heal = max(1, mon.max_hp // 16)
     heal = battle.events.emit(Event.ON_CALC_DRAIN, ctx, heal)
     return HandlerReturn(value=battle.modify_hp(mon, v=heal, source=mon))
@@ -1067,9 +1066,6 @@ def ねをはる_self_heal(battle: Battle, ctx: EventContext, value: Any) -> Han
 
     かいふくふうじ状態では ON_MODIFY_HEAL 経由でブロックされる。
     """
-    # ひんし(HP0)になったときは発動しない（同ターンの攻撃等で先にHPが0になった場合を含む）
-    if ctx.source.fainted:
-        return HandlerReturn(value=value)
     heal = max(1, ctx.source.max_hp // 16)
     heal = battle.events.emit(Event.ON_CALC_DRAIN, ctx, heal)
     return HandlerReturn(value=battle.modify_hp(ctx.source, v=heal, source=ctx.source))


### PR DESCRIPTION
## Summary
- fuzz_log/fuzzループが「瀕死になったポケモンに対してハンドラが誤発動/不発動する」バグを20件以上、1件ずつ場当たり的に修正してきた根本原因を調査し、横断的に解消する。
- 現状は (a) `EventManager.emit(skip_if_subject_fainted=True)`（4箇所のみ、ON_SWITCH_IN系）、(b) 各ハンドラ内の手書き `if mon.fainted: return`（45箇所）、(c) `MoveExecutor._check_target_fainted`（技実行専用の別ロジック）の3つが場当たり的に併存しており、新規ハンドラ追加のたびに書き忘れが起きていた。
- `Handler`（`core/handler.py`）に宣言的フィールド `allow_fainted_subject: bool = False` を追加し、`EventManager._check_handler_validity` で `subject_spec` 解決先の瀕死判定を全イベント共通で一元化。既定は「瀕死ならスキップ」で、45箇所の手書きガードのうち約31箇所は削除できた。
- 瀕死になった当人自身の効果が発動すべき少数のケース（`Event.ON_MOVE_KO` 系、ほろびのボディ/さめはだ等の接触反撃系アビリティ、フィールドのターン経過処理、HPコスト技で自身が先に瀕死になっても威力計算・PP回復等は継続すべきケース）には `allow_fainted_subject=True` を明示し、理由をコメントで残した。`MoveHandler` は技実行フロー固有の性質上、既定を `True` に反転し、逆に自身の瀕死で打ち切るべきアイススピナーのみ明示的に `False` にした。
- `emit()` の `skip_if_subject_fainted` 引数は同メカニズムに統合されたため削除（呼び出し側4箇所も追随して簡素化）。

## Test plan
- [x] `python -m pytest tests/ -v` 全件パス（5972 passed, 1 skipped）
- [x] 既存の瀕死ガード関連の回帰テスト（`tests/test_fuzz_regressions.py`、`tests/abilities/test_ability_ma.py` のムラっけテスト等）が引き続きパスすることを確認
- [x] `scripts/fuzz/fuzz_log_battle.py --count 50` を実行し、未捕捉例外(crashed=True)が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)