### PR TITLE
feat: シングルバトルで無効果な技をlearnsetから除外するフィルタを追加

### DIFF
--- a/docs/tests/test_data_integrity.md
+++ b/docs/tests/test_data_integrity.md
@@ -1,6 +1,7 @@
 # test_data_integrity
 
-テスト数: 2
+テスト数: 3
 
 - [x] 技データ_flagsが全てMoveFlagに定義されている
+- [x] 技データ_no_effect_in_singlesの技はPokemonのlearnsetから除外される
 - [x] 特性データ_flagsが全てAbilityFlagに定義されている

--- a/src/jpoke/data/learnset.py
+++ b/src/jpoke/data/learnset.py
@@ -16,6 +16,9 @@ file = resource_path('data', 'ps-champ-ja', "learnsets.json")
 with open(file, encoding='utf-8') as f:
     data = json.load(f)
 
+# ps-champ-ja由来の生データ（フィルタなし）。シングルバトルで戦闘に影響しない技の除外は
+# Pokemon.learnset側で行う（data.move.MOVESへの依存はdata.pokedex経由の循環インポートに
+# なるため、ここでは行えない）。
 LEARNSETS: dict[PokemonName, frozenset[MoveName]] = {
     name: frozenset(moves) for name, moves in data.items()
 }

--- a/src/jpoke/data/moves/move_a.py
+++ b/src/jpoke/data/moves/move_a.py
@@ -331,6 +331,7 @@ MOVES_A: dict[MoveName, MoveData] = {
         },
     ),
     "アロマミスト": MoveData(
+        flags={"no_effect_in_singles"},  # 味方専用（target=adjacentAlly、自分には使えない）。シングルでは対象不在
         handlers={},  # 追加効果なし
     ),
     "あわ": MoveData(
@@ -400,7 +401,7 @@ MOVES_A: dict[MoveName, MoveData] = {
         handlers={},  # 追加効果なし
     ),
     "いかりのこな": MoveData(
-        flags={"non_copycat"},
+        flags={"non_copycat", "no_effect_in_singles"},  # シングルは対象が元々1体のみでリダイレクト効果が無意味
         handlers={},  # 追加効果なし
     ),
     "いかりのまえば": MoveData(
@@ -875,7 +876,7 @@ MOVES_A: dict[MoveName, MoveData] = {
         category="status",
         pp=40,
         target="self",
-        flags={"non_negoto", "non_copycat"},  # まねっこでコピー不可
+        flags={"non_negoto", "non_copycat", "no_effect_in_singles"},  # まねっこでコピー不可
         handlers={},  # 効果のないわざ（戦闘上の効果なし）
     ),
     "おかたづけ": MoveData(
@@ -891,6 +892,7 @@ MOVES_A: dict[MoveName, MoveData] = {
         }
     ),
     "おさきにどうぞ": MoveData(
+        flags={"no_effect_in_singles"},  # 行動順操作技。シングルは行動者が2体のみで順序が変わらない
         handlers={},  # ダブル専用（本プロジェクトはシングルバトル専用のため対象外）
     ),
     "おしゃべり": MoveData(

--- a/src/jpoke/data/moves/move_ha.py
+++ b/src/jpoke/data/moves/move_ha.py
@@ -219,7 +219,7 @@ MOVES_HA: dict[MoveName, MoveData] = {
         category="status",
         pp=40,
         target="self",
-        flags={"gravity_restricted"},
+        flags={"gravity_restricted", "no_effect_in_singles"},  # 公式に戦闘上の効果を持たない技
         handlers={
             Event.ON_TRY_MOVE_1: h.MoveHandler(
                 h.gravity_restricted_fail,

--- a/src/jpoke/data/moves/move_ka.py
+++ b/src/jpoke/data/moves/move_ka.py
@@ -959,7 +959,7 @@ MOVES_KA: dict[MoveName, MoveData] = {
         handlers={},  # 追加効果なし
     ),
     "このゆびとまれ": MoveData(
-        flags={"non_copycat"},
+        flags={"non_copycat", "no_effect_in_singles"},  # シングルは対象が元々1体のみでリダイレクト効果が無意味
         handlers={},  # 追加効果なし
     ),
     "コメットパンチ": MoveData(
@@ -1015,6 +1015,7 @@ MOVES_KA: dict[MoveName, MoveData] = {
         },
     ),
     "コーチング": MoveData(
+        flags={"no_effect_in_singles"},  # 味方専用（target=adjacentAlly、自分を除く）。シングルでは対象不在
         handlers={},  # 追加効果なし
     ),
     "コートチェンジ": MoveData(

--- a/src/jpoke/data/moves/move_sa.py
+++ b/src/jpoke/data/moves/move_sa.py
@@ -127,6 +127,7 @@ MOVES_SA: dict[MoveName, MoveData] = {
         }
     ),
     "サイドチェンジ": MoveData(
+        flags={"no_effect_in_singles"},  # 味方と位置を交代する技（Ally Switch）。シングルでは味方が不在で不発
         handlers={},  # ダブル専用（本プロジェクトはシングルバトル専用のため対象外）
     ),
     "さいはい": MoveData(
@@ -147,6 +148,7 @@ MOVES_SA: dict[MoveName, MoveData] = {
         }
     ),
     "さきおくり": MoveData(
+        flags={"no_effect_in_singles"},  # 行動順操作技。シングルは行動者が2体のみで順序が変わらない
         handlers={},  # ダブル専用（本プロジェクトはシングルバトル専用のため対象外）
     ),
     "さばきのつぶて": MoveData(

--- a/src/jpoke/data/moves/move_ta.py
+++ b/src/jpoke/data/moves/move_ta.py
@@ -566,6 +566,7 @@ MOVES_TA: dict[MoveName, MoveData] = {
         }
     ),
     "てだすけ": MoveData(
+        flags={"no_effect_in_singles"},  # 味方専用（target=adjacentAlly）。シングルでは対象不在
         handlers={},  # ダブル専用（本プロジェクトはシングルバトル専用のため対象外）
     ),
     "てっていこうせん": MoveData(
@@ -1162,7 +1163,7 @@ MOVES_TA: dict[MoveName, MoveData] = {
         }
     ),
     "ドラゴンエール": MoveData(
-        flags={"sound"},
+        flags={"sound", "no_effect_in_singles"},  # 味方専用（target=adjacentAlly）。シングルでは対象不在
         handlers={},  # ダブル専用（本プロジェクトはシングルバトル専用のため対象外）
     ),
     "ドラゴンクロー": MoveData(

--- a/src/jpoke/model/pokemon.py
+++ b/src/jpoke/model/pokemon.py
@@ -524,10 +524,18 @@ class Pokemon:
     def learnset(self) -> frozenset[MoveName]:
         """覚えられる技名の集合を取得する。
 
+        シングルバトルで戦闘に一切影響しない技（MoveFlag「no_effect_in_singles」参照）は
+        あらかじめ除外する。data.moveの遅延インポートは、data.pokedex経由の循環インポートを
+        避けるため（learnsetローダー自体はps-champ-ja由来の生データのみを保持する）。
+
         Returns:
-            覚えられる技名の集合（ps-champ-ja由来のスナップショット）
+            覚えられる技名の集合（ps-champ-ja由来のスナップショットから、対戦に影響しない技を除いたもの）
         """
-        return self.data.learnset
+        from jpoke.data.move import MOVES
+        return frozenset(
+            move for move in self.data.learnset
+            if "no_effect_in_singles" not in MOVES[move].flags
+        )
 
     def can_learn(self, move_name: MoveName) -> bool:
         """指定された技を覚えられるか判定する。

--- a/src/jpoke/types/literals.py
+++ b/src/jpoke/types/literals.py
@@ -115,6 +115,8 @@ MoveFlag = Literal[
     "non_encore",  # アンコールで固定できない技。
     "non_negoto",  # ねごとで選ばれない技。
     "non_onnen",  # おんねんのPP消失対象外の技（わるあがき等）。
+    "no_effect_in_singles",  # シングルバトルでは戦闘に一切影響しない技（味方専用で対象不在・
+                              # おいわい等の公式無効果技等）。learnsetのフィルタ用途。
     "unprotectable",  # まもる等の防御効果を無視する技。
     "unreflectable",  # マジックコート・マジックミラーで跳ね返されない変化技。
     "ohko",  # 一撃必殺技。

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -7,7 +7,8 @@ from typing import get_args
 
 import pytest
 
-from jpoke.data import ABILITIES, MOVES
+from jpoke.data import ABILITIES, MOVES, POKEDEX
+from jpoke.model.pokemon import Pokemon
 from jpoke.types import AbilityFlag, MoveFlag
 
 
@@ -20,6 +21,21 @@ def test_技データ_flagsが全てMoveFlagに定義されている():
         if unknown:
             errors.append(f"{name}: {sorted(unknown)}")
     assert not errors, "MoveFlag に未定義のフラグ:\n" + "\n".join(errors)
+
+
+def test_技データ_no_effect_in_singlesの技はPokemonのlearnsetから除外される():
+    """no_effect_in_singlesフラグを持つ技（味方専用で対象不在・公式無効果技等）が、
+    Pokemon.learnset（実戦で使う覚えられる技の集合）に一切含まれないことを確認する。
+    """
+    no_effect_moves = {name for name, data in MOVES.items() if "no_effect_in_singles" in data.flags}
+    assert no_effect_moves, "no_effect_in_singlesフラグを持つ技が1件も無い（フラグ定義の確認漏れ）"
+
+    errors = []
+    for name in POKEDEX:
+        leaked = Pokemon(name).learnset & no_effect_moves
+        if leaked:
+            errors.append(f"{name}: {sorted(leaked)}")
+    assert not errors, "learnsetから除外されていない技:\n" + "\n".join(errors)
 
 
 def test_特性データ_flagsが全てAbilityFlagに定義されている():


### PR DESCRIPTION
## Summary
- `MoveFlag` に `no_effect_in_singles` を新設し、シングルバトルでは戦闘に一切影響しない技11件に付与
  - 味方専用で対象不在（target=adjacentAlly）: てだすけ・アロマミスト・コーチング・ドラゴンエール
  - シングルでは意味を持たないリダイレクト/行動順操作技: いかりのこな・このゆびとまれ・おさきにどうぞ・さきおくり
  - 味方と位置を交代する技で対象不在: サイドチェンジ
  - 公式に無効果の技: おいわい・はねる
- `Pokemon.learnset` プロパティで上記フラグを持つ技を除外するようにした（`can_learn()` もこれを参照するため自動的に反映される）
- ローダー本体（`data/learnset.py`）ではなく `Pokemon.learnset` 側で遅延importによりフィルタしている。理由: `data.move`（MOVES）を`data/learnset.py`のトップレベルでimportすると `data.move → moves/move_symbol → handlers/move_attack → data.pokedex → data.learnset → data.move` の循環importになるため
- 除外対象の判定は名前や`target`フィールドのみからの機械的推測ではなく、`docs/progress/move.md`の効果文言を個別に確認した上で行った（例: `target=allies/allyTeam`の とおぼえ・いのちのしずく・いやしのすず はシングルでも自分/控え全体に効果が及ぶため除外していない。サイドチェンジ(Ally Switch)と コートチェンジ(Court Change)は紛らわしいが別技で、後者は既存実装済みのため対象外）
- `tests/test_data_integrity.py` に、`no_effect_in_singles`フラグを持つ技が全ポケモンの`Pokemon.learnset`に一切含まれないことを検証するテストを追加

## Test plan
- [x] `python -m pytest tests/ -v` 全件パス（5994 passed, 1 skipped）
- [x] `python scripts/sort_data/sort_moves.py` 実行済み（差分なし）
- [x] `python scripts/sort_tests.py tests/test_data_integrity.py` / `python scripts/generate_test_list.py` 実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)