### PR TITLE
fix: transform()のAbility()呼び出しでmypyの型エラーを修正

### DIFF
--- a/src/jpoke/core/battle.py
+++ b/src/jpoke/core/battle.py
@@ -4,7 +4,7 @@
 プレイヤー、ポケモン、技、場の状態などを一元管理し、バトルの進行を制御します。
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 if TYPE_CHECKING:
     from .lethal import LethalResult
     from .context import AttackContext
@@ -1139,7 +1139,7 @@ class Battle:
         if is_active:
             self.events.emit(Event.ON_ABILITY_DISABLED, EventContext(source=source))
             source.ability.unregister_handlers(self.events, source)
-        source.ability = Ability(target.ability.name)
+        source.ability = Ability(cast(AbilityName, target.ability.name))
         if is_active:
             source.ability.register_handlers(self.events, source)
             self.events.emit(Event.ON_ABILITY_ENABLED, EventContext(source=source))


### PR DESCRIPTION
## Summary
- `main`（PR #283「おどりこ・かわりもの・へんしん・ゆびをふるを実装」）がCI失敗のままマージされており、以降にpushされるPRのCI（mypy）が軒並み赤くなっていた
- `Battle.transform()` の `Ability(target.ability.name)` が `target.ability.name`（`GameEffect.name: str`）を `Ability.__init__(name: AbilityName)`（Literal型）にそのまま渡しており、mypyの `arg-type` エラーになっていた
- 実行時には常に有効な特性名文字列が渡るため動作上の問題はない。既存の同種箇所（`ability_manager.py` 等）に倣い `cast(AbilityName, ...)` を追加した

## Test plan
- [x] `mypy` がクリーンに通ることを確認
- [x] `pytest tests/ -k "へんしん or かわりもの or transform"` 8 passed
- [x] `pytest tests/ -q`（examples除く）6032 passed, 0 failed
- [x] `ruff check src/jpoke/core/battle.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)