### PR TITLE
fix: fuzz_log/seed2991_メガソーラー使用中に本物の天候が変化すると天候ハンドラが二重登録されるバグ

### DIFF
--- a/src/jpoke/core/field_manager.py
+++ b/src/jpoke/core/field_manager.py
@@ -133,6 +133,12 @@ class ExclusiveFieldManager(BaseFieldManager[T]):
 
     Attributes:
         current: 現在有効なフィールド
+        change_version: current_name が実際に変化した回数を数えるカウンター。
+            メガソーラー等、一時的に current_name を仮想的に上書きする効果が、
+            その最中に本物の変化（apply/remove/tick_down_current 経由）が
+            発生したかどうかを検知するために使う（直接の代入である
+            `current_name = ...` はカウントされない。`メガソーラー_deactivate`
+            参照）。
     """
 
     def __init__(self, battle: Battle, owners: tuple[Player, ...], kind: Any):
@@ -154,6 +160,7 @@ class ExclusiveFieldManager(BaseFieldManager[T]):
 
         self.inactive_name: T = cast(T, "")  # 非アクティブ状態を表すフィールド名
         self.current_name: T = self.inactive_name
+        self.change_version: int = 0
 
     @property
     def current(self) -> Field:
@@ -196,6 +203,7 @@ class ExclusiveFieldManager(BaseFieldManager[T]):
 
         self._activate_field(name, modified_count)
         self.current_name = name
+        self.change_version += 1
         self._events.emit(Event.ON_FIELD_CHANGE)
 
         # 瀕死交代・緊急交代など、このターンのON_TURN_END通過後に新規発動した場合は
@@ -215,6 +223,7 @@ class ExclusiveFieldManager(BaseFieldManager[T]):
             return False
         self._deactivate_field(self.current)
         self.current_name = self.inactive_name
+        self.change_version += 1
         self._events.emit(Event.ON_FIELD_CHANGE)
         return True
 
@@ -241,6 +250,7 @@ class ExclusiveFieldManager(BaseFieldManager[T]):
         if not field.count:
             self._deactivate_field(field)
             self.current_name = self.inactive_name
+            self.change_version += 1
             self._events.emit(Event.ON_FIELD_CHANGE)
 
 

--- a/src/jpoke/handlers/ability.py
+++ b/src/jpoke/handlers/ability.py
@@ -4387,13 +4387,21 @@ def メガソーラー_activate(battle: Battle, ctx: AttackContext, value: Any) 
                 wm.fields["はれ"].register_handlers(battle.events, player)
 
         wm.current_name = "はれ"
+        mon.ability.saved_weather_version = wm.change_version
         mon.ability.state = "active"
     mon.ability.weather_override_depth += 1
     return HandlerReturn(value=value)
 
 
 def メガソーラー_deactivate(battle: Battle, ctx: AttackContext, value: Any) -> HandlerReturn:
-    """メガソーラー特性: 技使用後に天候を元に戻す（最も外側の呼び出しでのみ実行）。"""
+    """メガソーラー特性: 技使用後に天候を元に戻す（最も外側の呼び出しでのみ実行）。
+
+    技使用中に相手のすなはき等で本物の天候が実際に変化した場合
+    （`WeatherManager.change_version` が上書き開始時点から変化している場合）は、
+    仮想上書き（はれ）は既に `apply()` 経由で正規に解除・置き換え済みのため、
+    無条件に元の天候へ戻さず、その本物の天候変化をそのまま維持する
+    （signature: LogInconsistency@ability.py:メガソーラー_deactivate:4395）。
+    """
     if ctx.move.name in _メガソーラー_WEATHER_SETTING_MOVES:
         return HandlerReturn(value=value)
 
@@ -4407,19 +4415,23 @@ def メガソーラー_deactivate(battle: Battle, ctx: AttackContext, value: Any
         return HandlerReturn(value=value)
 
     wm = battle.weather_manager
-    original_name = mon.ability.saved_weather_name
-    if original_name != "はれ":
-        # 「はれ」のハンドラを解除して元天候のハンドラを復元する
-        for player in wm.fields["はれ"].owners:
-            wm.fields["はれ"].unregister_handlers(battle.events, player)
-        wm.fields["はれ"].count = mon.ability.saved_weather_count
-        if wm.fields[original_name].is_active:
-            for player in wm.fields[original_name].owners:
-                wm.fields[original_name].register_handlers(battle.events, player)
-    wm.current_name = original_name
+    if wm.change_version == mon.ability.saved_weather_version:
+        # 技使用中に本物の天候変化が発生していない場合のみ、仮想上書きを元に戻す
+        original_name = mon.ability.saved_weather_name
+        if original_name != "はれ":
+            # 「はれ」のハンドラを解除して元天候のハンドラを復元する
+            for player in wm.fields["はれ"].owners:
+                wm.fields["はれ"].unregister_handlers(battle.events, player)
+            wm.fields["はれ"].count = mon.ability.saved_weather_count
+            if wm.fields[original_name].is_active:
+                for player in wm.fields[original_name].owners:
+                    wm.fields[original_name].register_handlers(battle.events, player)
+        wm.current_name = original_name
+
     mon.ability.state = ""
     mon.ability.saved_weather_name = ""
     mon.ability.saved_weather_count = 0
+    mon.ability.saved_weather_version = 0
     return HandlerReturn(value=value)
 
 

--- a/src/jpoke/model/ability.py
+++ b/src/jpoke/model/ability.py
@@ -48,6 +48,11 @@ class Ability(GameEffect):
         """メガソーラー専用: ねごと・まねっこ等で技実行がネストした場合に対応する深度カウンター。
         最も外側の ON_BEGIN_MOVE でのみ本来の天候を保存し、深度が0に戻る
         ON_END_MOVE でのみ復元する。"""
+        self.saved_weather_version: int = 0
+        """メガソーラー専用: 天候を上書きした時点の WeatherManager.change_version を
+        一時保存する。技使用中に相手のすなはき等で本物の天候変化が発生したかどうかを
+        判定するために使う（一致していれば仮想上書きのみ、一致しなければ本物の
+        天候変化が発生済みなので復元処理をスキップする。`メガソーラー_deactivate` 参照）。"""
 
         self.data: AbilityData  # 型ヒントのための属性。実際のデータはsuper().__init__で設定される
 
@@ -70,6 +75,7 @@ class Ability(GameEffect):
         self.saved_weather_name = ""
         self.saved_weather_count = 0
         self.weather_override_depth = 0
+        self.saved_weather_version = 0
         self.reset_enable_state()
 
     def reset_enable_state(self):

--- a/tests/abilities/test_ability_ma.py
+++ b/tests/abilities/test_ability_ma.py
@@ -1001,6 +1001,24 @@ def test_メガソーラー_ノーてんき相手でも有効():
     assert battle.damage_calculator.power_modifier == 6144
 
 
+def test_メガソーラー_まねっこでネストした技使用中の天候変化も維持される():
+    """まねっこ経由で技実行がネストする場合でも（weather_override_depth>0の内側の
+    deactivateでは判定せず、最も外側のdeactivateでのみ判定する）、ネスト中に
+    相手のすなはきで本物の天候が変化していれば、外側のdeactivateでもそれを
+    正しく維持する。"""
+    battle = t.start_battle(
+        team0=[Pokemon("ピカチュウ", ability_name="メガソーラー", move_names=["まねっこ"])],
+        team1=[Pokemon("カビゴン", ability_name="すなはき", move_names=["ひのこ"])],
+        accuracy=100,
+    )
+    t.run_move(battle, 1)  # カビゴン: ひのこ（まねっこのコピー対象を作る。まだすなはきは発動しない）
+    t.run_move(battle, 0)  # ピカチュウ: まねっこ（内部でひのこがネストして実行され、カビゴンのすなはきが発動する）
+    assert battle.weather.name == "すなあらし"
+    assert battle.actives[0].ability.state == ""
+    assert battle.actives[0].ability.weather_override_depth == 0
+    assert battle.actives[0].ability.saved_weather_version == 0
+
+
 def test_メガソーラー_まねっこでネストしても天候が正しく元に戻る():
     """まねっこ経由で技実行がネストしても（ON_BEGIN_MOVE/ON_END_MOVEが二重発火しても）、
     行動全体が終わった後には実際の天候が正しく元に戻る。"""
@@ -1032,6 +1050,44 @@ def test_メガソーラー_天候なしでみず技が0_5倍():
     )
     t.run_move(battle, 0)
     assert battle.damage_calculator.power_modifier == 2048
+
+
+def test_メガソーラー_技使用中にすなはきで本物の天候が変化すると復元されない():
+    """メガソーラー使用中に相手のすなはきで本物の天候がすなあらしに変化した場合、
+    技終了時に元の天候（天候なし）へ誤って戻さず、すなあらしをそのまま維持する
+    （fuzz_log seed=2991 で発見されたバグの回帰確認。孤児化した Field オブジェクトが
+    次回の再発動でハンドラ二重登録・ターン終了処理の重複発火を起こす原因になっていた）。"""
+    battle = t.start_battle(
+        team0=[Pokemon("ピカチュウ", ability_name="メガソーラー", move_names=["ひのこ"])],
+        team1=[Pokemon("カビゴン", ability_name="すなはき")],
+        accuracy=100,
+    )
+    t.run_move(battle, 0)
+    assert battle.weather.name == "すなあらし"
+    assert battle.actives[0].ability.state == ""
+    assert battle.actives[0].ability.weather_override_depth == 0
+    assert battle.actives[0].ability.saved_weather_version == 0
+
+    # 次のターンも正常にすなあらしのターン終了処理が1回だけ発火することを確認
+    # （孤児化していた場合はハンドラ二重登録によりダメージが2回入る）
+    mon = battle.actives[0]
+    hp_before = mon.hp
+    t.end_turn(battle)
+    damage = hp_before - mon.hp
+    assert damage == mon.max_hp // 16
+
+
+def test_メガソーラー_技使用中に天候変化がなければ従来通り元に戻る():
+    """回帰確認: すなはき等の介在がない通常ケースでは、技終了後に元の天候
+    （あめ）へ正しく復元される（change_version が変化しないケース）。"""
+    battle = t.start_battle(
+        team0=[Pokemon("ピカチュウ", ability_name="メガソーラー", move_names=["ひのこ"])],
+        team1=[Pokemon("カビゴン")],
+        weather=("あめ", 5),
+    )
+    t.run_move(battle, 0)
+    assert battle.weather.name == "あめ"
+    assert battle.actives[0].ability.saved_weather_version == 0
 
 
 def test_メガソーラー_攻撃後に天候が元に戻る():


### PR DESCRIPTION
メガソーラー使用中に相手のすなはき等で本物の天候が実際に変化した場合、技終了時に
無条件で元の天候へ戻していたため、変化後の天候のFieldオブジェクトがis_active=True・
ハンドラ登録済みのまま孤児化し、次回同じ天候が再activateされた際にハンドラが二重登録
される不整合を修正した。ExclusiveFieldManagerにchange_versionカウンターを追加し、
メガソーラー発動時に記録した値と技終了時の値を比較することで、技使用中に本物の天候変化が
あったかどうかを検知し、変化があった場合は復元処理をスキップして実天候を維持するようにした。

回帰テストとして、すなはきとの相互作用・まねっこによるネスト・従来通りの復元ケースを
tests/abilities/test_ability_ma.py に追加した。
