### PR TITLE
fix: lethal.pyの未解決マージ衝突による構文エラーを修正

### DIFF
--- a/src/jpoke/core/lethal.py
+++ b/src/jpoke/core/lethal.py
@@ -201,7 +201,6 @@ def calc_lethal(battle: Battle,
     move_list = _generate_move_list(moves)
 
     return _lethal_loop(initial_hp, hp_dist, battle, attacker, defender, move_list, critical, move_secondary, max_attack)
-    return _lethal_loop(initial_hp, hp_dist, battle, attacker, defender, move_list, critical, move_secondary, max_attack)
 
 
 def _generate_move_list(
@@ -234,8 +233,6 @@ def _generate_move_list(
         return [(to_move(moves), 1)]
 
 
-def _lethal_loop(initial_hp: int,
-                 hp_dist: StateDist,
 def _lethal_loop(initial_hp: int,
                  hp_dist: StateDist,
                  battle: Battle,
@@ -445,7 +442,7 @@ def _get_move_handlers(event: LethalEvent, ctx: LethalContext) -> list[LethalHan
 
 def _get_global_field_handlers(event: LethalEvent, battle: Battle) -> list[LethalHandler]:
     """天候・地形・共通フィールドから該当ハンドラを取得する。"""
-    fields = [battle.weather, battle.terrain] +
+    fields = [battle.weather, battle.terrain] + \
         list(battle.global_manager.fields.values())
     candidates = [field.data.lethal_handlers.get(
         event) for field in fields if field.is_active]


### PR DESCRIPTION
## Summary
- \`origin/main\` の直前のマージコミット（9161ef7af）で解消漏れが残り、\`src/jpoke/core/lethal.py\` に構文エラーが発生し、\`jpoke\` パッケージのimport自体が失敗する状態になっていた
  - \`calc_lethal\` 内の \`return _lethal_loop(...)\` 行が重複
  - \`_lethal_loop\` の関数シグネチャ冒頭2行が重複
  - \`_get_move_handlers\` 内の複数行にまたがるリスト結合式で行継続（バックスラッシュ）が欠落
- fuzz_logループのバトル生成が \`ImportError\`（実際は\`SyntaxError\`）で即座に失敗することで発覚

## Test plan
- [x] \`python -c "import jpoke"\` が成功することを確認
- [x] \`python -m pytest tests/ -q\` で 6108 passed / 7 failed（失敗7件は本修正と無関係な既存の問題: examples配下のnotebook規約・スモークテスト、および\`test_copy.py\`の\`switch_manager\`関連1件。詳細は別途報告）
- [x] \`python -m pytest tests/test_lethal.py -q\` で118件全て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)