### PR TITLE
lethal: LethalPokemonStateのboosts/ailmentをStateに持たせて一般化

### DIFF
--- a/src/jpoke/core/lethal.py
+++ b/src/jpoke/core/lethal.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 
 from jpoke.types import Stat, AilmentName, LethalSubject
 from jpoke.enums import LethalEvent
-from jpoke.utils.lethal_dist import StateDist, to_dist, add_dist, subtract_dist
+from jpoke.utils.lethal_dist import State, StateDist, to_dist, add_dist, subtract_dist
 
 
 @dataclass(frozen=True)
@@ -65,8 +65,12 @@ class LethalContext:
 
 @dataclass
 class LethalPokemonState:
-    # TODO: 一般化という観点では、これらの情報はHitごとに一意に定まる確証はないため、State に持たせるべき。
     """致死率計算時点でのポケモン片側の状態スナップショット。
+
+    実体は hp_dist の各 State が枝ごとに保持する attacker_boosts/attacker_ailment/
+    defender_boosts/defender_ailment（utils/lethal_dist.State）であり、この
+    dataclass はそこから代表枝を読み出した表示用のビューにすぎない
+    （`_pokemon_states` 参照）。
 
     Attributes:
         boosts: 計算時のランク補正
@@ -109,10 +113,12 @@ class LethalHitResult:
         if not isinstance(other, LethalHitResult):
             return NotImplemented
 
-        # TODO: hp_distの合成ロジックを変更したのでテストで検証する
         hp_dist = subtract_dist(self.hp_dist, subtract_dist(
             other.initial_hp, other.hp_dist))
         damage_dist = add_dist(self.damage_dist, other.damage_dist)
+        # hp_dist の各枝には other 側の状態タグ（attacker_boosts 等）が引き継がれる
+        # （subtract_dist は同期済み=Noneでない側を優先するため。utils/lethal_dist._convolve 参照）。
+        attacker_state, defender_state = _pokemon_states(hp_dist)
         return LethalHitResult(
             initial_hp=self.initial_hp,
             move=other.move,
@@ -120,8 +126,8 @@ class LethalHitResult:
             hit_count=1,
             hp_dist=hp_dist,
             damage_dist=damage_dist,
-            attacker_state=other.attacker_state,
-            defender_state=other.defender_state,
+            attacker_state=attacker_state,
+            defender_state=defender_state,
         )
 
     def _counter(self, dist: StateDist) -> dict[int, int]:
@@ -161,6 +167,51 @@ class LethalHitResult:
 def fainted(dist: StateDist) -> bool:
     """分布内に HP=0 の状態が存在するか確認する。"""
     return any(state.value == 0 for state in dist)
+
+
+def _boosts_key(boosts: dict[Stat, int]) -> tuple[tuple[str, int], ...]:
+    """dict[Stat, int] を State のタグとして使えるハッシュ可能な形に変換する。"""
+    return tuple(sorted(boosts.items()))
+
+
+def _stamp_dist(hp_dist: StateDist, *,
+                attacker_boosts: tuple[tuple[str, int], ...],
+                attacker_ailment: str,
+                defender_boosts: tuple[tuple[str, int], ...],
+                defender_ailment: str) -> StateDist:
+    """hp_dist の全ての枝に、現在の攻撃側・防御側の状態タグを同期する。
+
+    ハンドラは ctx.attacker / ctx.defender という実体を分岐によらず一括で書き換えるため、
+    ここで全枝に同じタグを書き込むことで hp_dist と実体の状態を一致させる
+    （個々のハンドラが分岐ごとに異なる状態を作るようになった場合はこの一括同期は不要になる）。
+    """
+    result: StateDist = defaultdict(int)
+    for state, freq in hp_dist.items():
+        new_state = State(
+            value=state.value,
+            ability_enabled=state.ability_enabled,
+            item_enabled=state.item_enabled,
+            attacker_boosts=attacker_boosts,
+            attacker_ailment=attacker_ailment,
+            defender_boosts=defender_boosts,
+            defender_ailment=defender_ailment,
+        )
+        result[new_state] += freq
+    return dict(result)
+
+
+def _pokemon_states(hp_dist: StateDist) -> tuple[LethalPokemonState, LethalPokemonState]:
+    """hp_dist の代表枝（同期済みなら全枝で共通）から攻撃側・防御側のスナップショットを復元する。"""
+    state = next(iter(hp_dist))
+    attacker_state = LethalPokemonState(
+        boosts=dict(state.attacker_boosts or ()),
+        ailment=cast(AilmentName, state.attacker_ailment or ""),
+    )
+    defender_state = LethalPokemonState(
+        boosts=dict(state.defender_boosts or ()),
+        ailment=cast(AilmentName, state.defender_ailment or ""),
+    )
+    return attacker_state, defender_state
 
 
 def calc_lethal(battle: Battle,
@@ -269,6 +320,7 @@ def _lethal_loop(initial_hp: int,
                 # 技の適用
                 hp_dist = _run_move(battle, ctx, hp_dist, every_event_handlers)
 
+                attacker_state, defender_state = _pokemon_states(hp_dist)
                 result = LethalHitResult(
                     initial_hp=initial_hp,
                     move=ctx.move,
@@ -276,12 +328,8 @@ def _lethal_loop(initial_hp: int,
                     hit_count=ctx.hit_count,
                     hp_dist=hp_dist,
                     damage_dist=ctx.damage_dist,
-                    attacker_state=LethalPokemonState(
-                        boosts=ctx.attacker.boosts.copy(), ailment=cast(AilmentName, ctx.attacker.ailment.name)
-                    ),
-                    defender_state=LethalPokemonState(
-                        boosts=ctx.defender.boosts.copy(), ailment=cast(AilmentName, ctx.defender.ailment.name)
-                    ),
+                    attacker_state=attacker_state,
+                    defender_state=defender_state,
                 )
                 results.append(result)
 
@@ -291,6 +339,7 @@ def _lethal_loop(initial_hp: int,
             # ターン終了時のハンドラを適用（たべのこし回復など）
             hp_dist = _run_turn_end(battle, ctx, hp_dist, every_event_handlers)
             results[-1].hp_dist = hp_dist  # ターン終了後の HP 分布を反映
+            results[-1].attacker_state, results[-1].defender_state = _pokemon_states(hp_dist)
             if fainted(hp_dist):
                 return results
 
@@ -404,7 +453,7 @@ def _run_move(battle: Battle,
 
     # ダメージを適用する（満タン枝・非満タン枝を分けて処理する）
     hp_dist = _apply_damage(battle, ctx, hp_dist)
-    _update_hp(ctx.defender, hp_dist)
+    hp_dist = _update_hp(ctx, hp_dist)
 
     # ヒット時のハンドラを適用（きのみ回復など）
     hp_dist = _emit(LethalEvent.ON_HIT, battle, ctx,
@@ -491,9 +540,18 @@ def _apply_handlers(battle: Battle,
     return hp_dist
 
 
-def _update_hp(mon: Pokemon, hp_dist: StateDist):
-    """分布内の最小 HP を mon.hp にセットする（後続ハンドラが参照するため）。"""
-    mon.hp = min(state.value for state in hp_dist)
+def _update_hp(ctx: LethalContext, hp_dist: StateDist) -> StateDist:
+    """分布内の最小 HP を防御側の hp にセットし（後続ハンドラが参照するため）、
+    hp_dist の全枝に現在の攻撃側・防御側の状態タグ（ランク補正・状態異常）を同期する。
+    """
+    ctx.defender.hp = min(state.value for state in hp_dist)
+    return _stamp_dist(
+        hp_dist,
+        attacker_boosts=_boosts_key(ctx.attacker.boosts),
+        attacker_ailment=ctx.attacker.ailment.name,
+        defender_boosts=_boosts_key(ctx.defender.boosts),
+        defender_ailment=ctx.defender.ailment.name,
+    )
 
 
 def _emit(event: LethalEvent,
@@ -511,9 +569,9 @@ def _emit(event: LethalEvent,
 
     handlers = _get_handlers(event, battle, ctx)
     hp_dist = _apply_handlers(battle, handlers, ctx, hp_dist)
-    _update_hp(ctx.defender, hp_dist)
+    hp_dist = _update_hp(ctx, hp_dist)
 
     hp_dist = _apply_handlers(battle, every_event_handlers, ctx, hp_dist)
-    _update_hp(ctx.defender, hp_dist)
+    hp_dist = _update_hp(ctx, hp_dist)
 
     return hp_dist

--- a/src/jpoke/handlers/lethal.py
+++ b/src/jpoke/handlers/lethal.py
@@ -22,6 +22,10 @@ def _damage(hp_dist: StateDist, v: int) -> StateDist:
             max(0, state.value - v),
             ability_enabled=state.ability_enabled,
             item_enabled=state.item_enabled,
+            attacker_boosts=state.attacker_boosts,
+            attacker_ailment=state.attacker_ailment,
+            defender_boosts=state.defender_boosts,
+            defender_ailment=state.defender_ailment,
         )
         new_dist[new_state] += freq
     return dict(new_dist)
@@ -96,7 +100,11 @@ def _heal_at_pinch(hp_dist: StateDist,
         new_state = State(
             min(state.value + heal, max_hp),
             ability_enabled=state.ability_enabled and keep_ability_enabled,
-            item_enabled=state.item_enabled and keep_item_enabled
+            item_enabled=state.item_enabled and keep_item_enabled,
+            attacker_boosts=state.attacker_boosts,
+            attacker_ailment=state.attacker_ailment,
+            defender_boosts=state.defender_boosts,
+            defender_ailment=state.defender_ailment,
         )
         new_dist[new_state] += freq
 
@@ -125,6 +133,10 @@ def _survive_at_full_hp(hp_dist: StateDist, consume: Literal["ability", "item"])
                 1,
                 ability_enabled=state.ability_enabled,
                 item_enabled=False if consume == "item" else state.item_enabled,
+                attacker_boosts=state.attacker_boosts,
+                attacker_ailment=state.attacker_ailment,
+                defender_boosts=state.defender_boosts,
+                defender_ailment=state.defender_ailment,
             )
         new_dist[state] += freq
     return dict(new_dist)
@@ -189,6 +201,10 @@ def アッキのみ_boost_def(battle: Battle, ctx: LethalContext, hp_dist: State
                 value=state.value,
                 ability_enabled=state.ability_enabled,
                 item_enabled=False,
+                attacker_boosts=state.attacker_boosts,
+                attacker_ailment=state.attacker_ailment,
+                defender_boosts=state.defender_boosts,
+                defender_ailment=state.defender_ailment,
             )
             new_dist[new_state] += freq
         else:
@@ -252,7 +268,11 @@ def _type_resist_berry(battle: Battle, ctx: LethalContext, hp_dist: StateDist,
         if state.item_enabled:
             new_state = State(state.value,
                               ability_enabled=state.ability_enabled,
-                              item_enabled=False)
+                              item_enabled=False,
+                              attacker_boosts=state.attacker_boosts,
+                              attacker_ailment=state.attacker_ailment,
+                              defender_boosts=state.defender_boosts,
+                              defender_ailment=state.defender_ailment)
             new_dist[new_state] += freq
         else:
             new_dist[state] += freq
@@ -308,6 +328,10 @@ def _add_second_hit(dist: StateDist) -> StateDist:
             state.value + second_hit,
             ability_enabled=state.ability_enabled,
             item_enabled=state.item_enabled,
+            attacker_boosts=state.attacker_boosts,
+            attacker_ailment=state.attacker_ailment,
+            defender_boosts=state.defender_boosts,
+            defender_ailment=state.defender_ailment,
         )
         new_dist[new_state] += freq
     return dict(new_dist)
@@ -533,6 +557,10 @@ def タラプのみ_boost_spd(battle: Battle, ctx: LethalContext, hp_dist: State
                 value=state.value,
                 ability_enabled=state.ability_enabled,
                 item_enabled=False,
+                attacker_boosts=state.attacker_boosts,
+                attacker_ailment=state.attacker_ailment,
+                defender_boosts=state.defender_boosts,
+                defender_ailment=state.defender_ailment,
             )
             new_dist[new_state] += freq
         else:
@@ -736,7 +764,11 @@ def ばけのかわ_block_damage(battle: Battle, ctx: LethalContext, hp_dist: St
             new_state = State(
                 value=max(0, state.value - damage),
                 ability_enabled=False,
-                item_enabled=state.item_enabled
+                item_enabled=state.item_enabled,
+                attacker_boosts=state.attacker_boosts,
+                attacker_ailment=state.attacker_ailment,
+                defender_boosts=state.defender_boosts,
+                defender_ailment=state.defender_ailment,
             )
             new_dist[new_state] += freq
         else:

--- a/src/jpoke/utils/lethal_dist.py
+++ b/src/jpoke/utils/lethal_dist.py
@@ -11,14 +11,24 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class State:
-    """HP分布の1要素。HP値と特性・道具の有効フラグを保持する。
+    """HP分布の1要素。HP値と特性・道具の有効フラグ、攻撃側・防御側のランク補正/状態異常を保持する。
 
     ability_enabled / item_enabled は「消耗型アイテム使用済み」など
     一度無効になったら戻らない状態を追跡するために使う。
+
+    attacker_boosts / attacker_ailment / defender_boosts / defender_ailment は
+    「その枝が観測された時点」でのポケモンの状態を表す。値は `None` を「未同期」の
+    センチネルとして扱う（`""` は「状態異常なし」という実際の値であり `None` とは区別する）。
+    実際の同期は `core/lethal.py` の `_update_hp` が行い、`_convolve` は分布演算の過程で
+    同期済みの側（`None` でない側）を優先して引き継ぐ。
     """
     value: int
     ability_enabled: bool = True
     item_enabled: bool = True
+    attacker_boosts: tuple[tuple[str, int], ...] | None = None
+    attacker_ailment: str | None = None
+    defender_boosts: tuple[tuple[str, int], ...] | None = None
+    defender_ailment: str | None = None
 
 
 # requires-python (>=3.10) 互換のため `type` エイリアス文（3.12+）は使わない
@@ -27,25 +37,35 @@ StateDist = dict[State, int]
 
 def to_dist(x: int | list[int] | StateDist,
             ability_enabled: bool = True,
-            item_enabled: bool = True) -> StateDist:
+            item_enabled: bool = True,
+            attacker_boosts: tuple[tuple[str, int], ...] | None = None,
+            attacker_ailment: str | None = None,
+            defender_boosts: tuple[tuple[str, int], ...] | None = None,
+            defender_ailment: str | None = None) -> StateDist:
     """整数・リスト・既存の StateDist を StateDist に正規化する。"""
     if isinstance(x, dict):
         return x
     elif isinstance(x, list):
         counter = Counter(x)
         return {
-            State(value=k, ability_enabled=ability_enabled, item_enabled=item_enabled): v
+            State(value=k, ability_enabled=ability_enabled, item_enabled=item_enabled,
+                  attacker_boosts=attacker_boosts, attacker_ailment=attacker_ailment,
+                  defender_boosts=defender_boosts, defender_ailment=defender_ailment): v
             for k, v in counter.items()
         }
     else:
-        key = State(value=x, ability_enabled=ability_enabled, item_enabled=item_enabled)
+        key = State(value=x, ability_enabled=ability_enabled, item_enabled=item_enabled,
+                    attacker_boosts=attacker_boosts, attacker_ailment=attacker_ailment,
+                    defender_boosts=defender_boosts, defender_ailment=defender_ailment)
         return {key: 1}
 
 
 def flip_dist(dist: StateDist) -> StateDist:
-    """分布の hp 符号を反転する（subtract_dist の内部用）。"""
+    """分布の hp 符号を反転する（subtract_dist の内部用）。フラグ・状態タグはそのまま引き継ぐ。"""
     return {
-        State(value=-k.value, ability_enabled=k.ability_enabled, item_enabled=k.item_enabled): v
+        State(value=-k.value, ability_enabled=k.ability_enabled, item_enabled=k.item_enabled,
+              attacker_boosts=k.attacker_boosts, attacker_ailment=k.attacker_ailment,
+              defender_boosts=k.defender_boosts, defender_ailment=k.defender_ailment): v
         for k, v in dist.items()
     }
 
@@ -53,7 +73,7 @@ def flip_dist(dist: StateDist) -> StateDist:
 def _clip_dist(dist: StateDist,
                minimum: int | None = None,
                maximum: int | None = None) -> StateDist:
-    """HP値を [minimum, maximum] にクランプし、同一 LethalState を集約する。"""
+    """HP値を [minimum, maximum] にクランプし、同一 LethalState を集約する。フラグ・状態タグはそのまま引き継ぐ。"""
     if minimum is None and maximum is None:
         return dist
 
@@ -64,14 +84,21 @@ def _clip_dist(dist: StateDist,
             hp = max(hp, minimum)
         if maximum is not None:
             hp = min(hp, maximum)
-        key = State(value=hp, ability_enabled=value.ability_enabled, item_enabled=value.item_enabled)
+        key = State(value=hp, ability_enabled=value.ability_enabled, item_enabled=value.item_enabled,
+                    attacker_boosts=value.attacker_boosts, attacker_ailment=value.attacker_ailment,
+                    defender_boosts=value.defender_boosts, defender_ailment=value.defender_ailment)
         result[key] += freq
     return dict(result)
 
 
 def _convolve(a: StateDist | list[int] | int,
               b: StateDist | list[int] | int) -> StateDist:
-    """2つの分布の畳み込みを計算する（HP を加算、フラグは AND）。"""
+    """2つの分布の畳み込みを計算する（HP を加算、フラグは AND）。
+
+    attacker_boosts 等の状態タグは b 側が同期済み（None でない）ならそちらを優先し、
+    未同期なら a 側を引き継ぐ。ダメージ量のような「状態を持たない」オペランドは常に
+    未同期（None）になるため、実質的に同期済みの側のタグがそのまま伝播する。
+    """
     x = to_dist(a)
     y = to_dist(b)
 
@@ -81,7 +108,15 @@ def _convolve(a: StateDist | list[int] | int,
             hp = vx.value + vy.value
             ability_enabled = vx.ability_enabled and vy.ability_enabled
             item_enabled = vx.item_enabled and vy.item_enabled
-            key = State(value=hp, ability_enabled=ability_enabled, item_enabled=item_enabled)
+            key = State(
+                value=hp,
+                ability_enabled=ability_enabled,
+                item_enabled=item_enabled,
+                attacker_boosts=vy.attacker_boosts if vy.attacker_boosts is not None else vx.attacker_boosts,
+                attacker_ailment=vy.attacker_ailment if vy.attacker_ailment is not None else vx.attacker_ailment,
+                defender_boosts=vy.defender_boosts if vy.defender_boosts is not None else vx.defender_boosts,
+                defender_ailment=vy.defender_ailment if vy.defender_ailment is not None else vx.defender_ailment,
+            )
             result[key] += fx * fy
     return dict(result)
 

--- a/tests/test_lethal.py
+++ b/tests/test_lethal.py
@@ -53,6 +53,37 @@ def test_Gのちから_ぼうぎょダウン_secondary無し():
     assert results[1].min_damage == results[0].min_damage
 
 
+def test_LethalHitResult加算_hp_dist合成ロジックが直接計算と一致する():
+    """LethalHitResult.__add__ のhp_dist合成ロジックを検証する。
+
+    たいあたりを2発直接計算した累積結果（1発目→2発目）と、1発目の結果に
+    「フルHPから1発だけ独立に計算した結果」を__add__で合成した結果は一致するはずである。
+    たいあたりはランク変化を伴わないため、2発目のダメージ分布は1発目と同一であり、
+    直接計算（2発とも同じ乱数範囲を畳み込む）と合成計算（__add__によるhp_dist差し引き）は
+    数学的に同じ結果になる。
+    """
+    battle_direct = t.start_battle(
+        team0=[Pokemon("ガブリアス")],
+        team1=[Pokemon("カイリュー")],
+    )
+    results_direct = t.calc_lethal(battle_direct, player_idx=0, moves=Move("たいあたり"), max_attack=2)
+
+    battle_second_hit = t.start_battle(
+        team0=[Pokemon("ガブリアス")],
+        team1=[Pokemon("カイリュー")],
+    )
+    results_second_hit = t.calc_lethal(battle_second_hit, player_idx=0, moves=Move("たいあたり"), max_attack=1)
+
+    combined = results_direct[0] + results_second_hit[0]
+
+    assert combined.attack_count == 2
+    assert combined.hit_count == 1
+    assert combined.hp_dist == results_direct[1].hp_dist
+    # damage_distは両ヒット分の合算（20~24 + 20~24）
+    assert combined.min_damage == 40
+    assert combined.max_damage == 48
+
+
 def test_Vジェネレート_ランクダウン_secondary有り():
     """Vジェネレート: secondary=Trueのとき、命中後に攻撃側のぼうぎょ・とくぼう・すばやさが1段階下がる"""
     battle = t.start_battle(


### PR DESCRIPTION
## Summary
- `core/lethal.py` の2つのTODOに対応
- `State`（`utils/lethal_dist.py`）に `attacker_boosts`/`attacker_ailment`/`defender_boosts`/`defender_ailment` を追加し、hp_distの枝ごとに攻撃側・防御側の状態（ランク補正・状態異常）を保持できるようにした（未同期を表す `None` センチネルと、実際の「状態異常なし」`""` を区別）
- `_update_hp` で hp_dist の全枝を現在のポケモン状態に同期し、`LethalHitResult.attacker_state`/`defender_state` と `__add__` の状態継承を ctx直接参照ではなく hp_dist 由来に変更
- `handlers/lethal.py` 内の手動 `State(...)` 構築8箇所を修正し、状態タグを引き継ぐようにした
- `LethalHitResult.__add__` の hp_dist合成ロジックが直接計算と数学的に一致することを検証するテストを追加

## Test plan
- [x] `python -m pytest tests/test_lethal.py -q` — 119件 pass
- [x] `python -m pytest tests/ -q` — 6108 passed, 1 skipped（既存の無関係な7件の失敗はセッション開始前からの未コミット差分に起因、本PR対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)