### PR TITLE
style: move_ha.pyの長い行を整形

### DIFF
--- a/src/jpoke/data/moves/move_ha.py
+++ b/src/jpoke/data/moves/move_ha.py
@@ -680,7 +680,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
     ),
     "ふくろだたき": MoveData(
         power=1,
-        multi_hit={"min": 1, "max": 6, "check_hit_each_time": False, "power_sequence": ()},
+        multi_hit={"min": 1, "max": 6,
+                   "check_hit_each_time": False, "power_sequence": ()},
         handlers={
             Event.ON_MODIFY_HIT_COUNT: h.MoveHandler(
                 ha.ふくろだたき_hit_count,
@@ -782,7 +783,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
                 lambda b, c, v: h.charge_into_volatile(b, c, v, "フリーズボルト"),
             ),
             Event.ON_MODIFY_PP_CONSUMED: h.MoveHandler(
-                lambda b, c, v: h.suppress_pp_on_charge_continuation(b, c, v, "フリーズボルト"),
+                lambda b, c, v: h.suppress_pp_on_charge_continuation(
+                    b, c, v, "フリーズボルト"),
             ),
             Event.ON_DAMAGE_HIT: h.MoveHandler(
                 ha.フリーズボルト_apply_paralysis_to_defender,
@@ -1073,7 +1075,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
             )
         },
         lethal_handlers={
-            LethalEvent.ON_HIT: LethalHandler(l.ホイールスピン_sharply_lower_attacker_spe)
+            LethalEvent.ON_HIT: LethalHandler(
+                l.ホイールスピン_sharply_lower_attacker_spe)
         }
     ),
     "ほうでん": MoveData(


### PR DESCRIPTION
## Summary
- \`src/jpoke/data/moves/move_ha.py\` 内の長い行（ふくろだたき・フリーズボルト・ホイールスピン）を
  複数行に整形。挙動の変更なし

## Test plan
- [x] \`python -m pytest tests/moves_attack/test_move_ha.py -q\` で286件全て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)