### PR TITLE
fix: Player.add_pokemonの引数名をability/item/movesに短縮

### DIFF
--- a/src/jpoke/core/player.py
+++ b/src/jpoke/core/player.py
@@ -56,13 +56,12 @@ class Player:
                     gender: Gender = "",
                     nature: Nature = "まじめ",
                     level: int = 50,
-                    ability_name: AbilityName = "",
-                    item_name: ItemName = "",
-                    move_names: list[MoveName] | None = None,
+                    ability: AbilityName = "",
+                    item: ItemName = "",
+                    moves: list[MoveName] | None = None,
                     tera_type: Type | None = None,
                     evs: dict[Stat, int] | None = None,
                     ivs: dict[Stat, int] | None = None) -> Pokemon:
-        # TODO: ability_name -> ability, item_name -> item, move_names -> moves に短縮したい
         """ポケモンを1体作成し、チームに追加する。
 
         `from jpoke import Pokemon` を使わずにチームを組める、`team` への
@@ -87,9 +86,9 @@ class Player:
             gender=gender,
             nature=nature,
             level=level,
-            ability_name=ability_name,
-            item_name=item_name,
-            move_names=move_names,
+            ability_name=ability,
+            item_name=item,
+            move_names=moves,
             tera_type=tera_type,
         )
         if evs is not None:

--- a/src/jpoke/data/moves/move_ha.py
+++ b/src/jpoke/data/moves/move_ha.py
@@ -680,7 +680,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
     ),
     "ふくろだたき": MoveData(
         power=1,
-        multi_hit={"min": 1, "max": 6, "check_hit_each_time": False, "power_sequence": ()},
+        multi_hit={"min": 1, "max": 6,
+                   "check_hit_each_time": False, "power_sequence": ()},
         handlers={
             Event.ON_MODIFY_HIT_COUNT: h.MoveHandler(
                 ha.ふくろだたき_hit_count,
@@ -782,7 +783,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
                 lambda b, c, v: h.charge_into_volatile(b, c, v, "フリーズボルト"),
             ),
             Event.ON_MODIFY_PP_CONSUMED: h.MoveHandler(
-                lambda b, c, v: h.suppress_pp_on_charge_continuation(b, c, v, "フリーズボルト"),
+                lambda b, c, v: h.suppress_pp_on_charge_continuation(
+                    b, c, v, "フリーズボルト"),
             ),
             Event.ON_DAMAGE_HIT: h.MoveHandler(
                 ha.フリーズボルト_apply_paralysis_to_defender,
@@ -1073,7 +1075,8 @@ MOVES_HA: dict[MoveName, MoveData] = {
             )
         },
         lethal_handlers={
-            LethalEvent.ON_HIT: LethalHandler(l.ホイールスピン_sharply_lower_attacker_spe)
+            LethalEvent.ON_HIT: LethalHandler(
+                l.ホイールスピン_sharply_lower_attacker_spe)
         }
     ),
     "ほうでん": MoveData(


### PR DESCRIPTION
## Summary
- \`Player.add_pokemon\` のシグネチャが \`ability_name\`/\`item_name\`/\`move_names\` のままだったが、
  \`examples/\` 配下のノートブックは既に短縮後の引数名（\`ability=\`/\`item=\`/\`moves=\`）で
  呼び出しており、\`TypeError\` で失敗していた
- シグネチャ内の既存TODOコメント（「ability_name -> ability, item_name -> item, move_names -> moves
  に短縮したい」）の通りに短縮し、内部で \`Pokemon.__init__\` へは引き続き旧名で渡すよう変更

## Test plan
- [x] \`python -m pytest tests/test_examples_smoke.py -k "02_fallback or 05_testing_helpers"\` で
  従来失敗していた2件が成功
- [x] \`python -m pytest tests/ -q\` で 6114 passed / 0 failed / 1 skipped（従来の7件の失敗が
  すべて解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)