### PR TITLE
feat: players/ の対応可能なTODOを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,16 @@
   でわるあがきを代用すると、交代コマンドが同時に存在する場合に誤ってそちらを
   返してしまう罠があった。実際にわるあがきを選ぶ際は `Command.STRUGGLE` を
   そのまま使えばよい（インデックス解決が不要な固定コマンドのため）
+- `Battle.copy(omniscient=True)` — 複製先の `observer` を `None` にするオプション
+  引数を追加。`choose_command()` が受け取る `battle` は情報隠蔽済みの観測
+  （`observer` が自分自身のコピー）であることがあり、木探索の内部シミュレーション
+  ではそのまま `copy()` した後に `sim.observer = None` を手動で設定する必要が
+  あった。`TreeSearchPlayer` をこのオプションを使う形に変更した。既定は `False`
+  で従来通りの挙動を維持する
+- `RandomPlayer.choose_selection()` — 選出番号を `battle.decision_random` で
+  ランダムに選ぶよう追加。従来は `Player.choose_selection()` の既定実装
+  （先頭から順に選出）を継承しており、`choose_command()` はランダムでも選出は
+  固定されたままだった
 
 ### Changed
 

--- a/src/jpoke/core/battle.py
+++ b/src/jpoke/core/battle.py
@@ -341,7 +341,10 @@ class Battle:
                     if hasattr(item, "update_reference"):
                         item.update_reference(self)
 
-    def copy(self, reseed: bool = False, copy_logs: bool = True) -> Battle:
+    def copy(self,
+             reseed: bool = False,
+             copy_logs: bool = True,
+             omniscient: bool = False) -> Battle:
         """Battleの複製を作成する。
 
         Args:
@@ -357,6 +360,15 @@ class Battle:
                 増えるため、木探索の内部シミュレーションのようにログを
                 参照しない用途で使うとコピー負荷を削減できる。既定は
                 Trueで、従来通り履歴を引き継いだ複製を作る。
+            omniscient: Trueの場合、複製先の `observer` を `None` にする。
+                `choose_command()` が受け取る `battle` は情報隠蔽済みの観測
+                （`observer` が自分自身に設定されたコピー）であることがあり、
+                これをそのまま `copy()` すると複製先にも `observer` が引き継がれ、
+                以降の `available_commands()` 等が相手の合法手をライブ計算せず
+                スナップショット（`last_available_commands`）を返し続けてしまう。
+                木探索の内部シミュレーションは全知（相手の合法手もライブ計算）を
+                前提とするため、既定はFalseで呼び出し元が明示したときだけ
+                `observer` を外す。
 
         Warning:
             copy_logs=Falseの場合、deepcopy実行中に複製元のevent_logger/command_logを
@@ -383,6 +395,8 @@ class Battle:
             new.seed = hash((self.seed, self._reseed_count)) & 0xFFFFFFFF
             new.random = Random(new.seed)
             new.decision_random = Random((new.seed + 0x9E3779B9) & 0xFFFFFFFF)
+        if omniscient:
+            new.observer = None
         return new
 
     @contextmanager

--- a/src/jpoke/players/random_player.py
+++ b/src/jpoke/players/random_player.py
@@ -10,15 +10,19 @@ from jpoke.enums import Command
 
 
 class RandomPlayer(Player):
-    # TODO: 選出もランダムにする
     """比較対象・ベースラインとして使う、合法手からランダムに選ぶだけのプレイヤー。
 
     `battle.decision_random`（行動選択専用の乱数系列）を使って選ぶため、
     `Battle(seed=...)` による再現性を壊さない。`Player.battle_against()` で
     複数回対戦して統計比較する場合、既定の `Player.choose_command()`（常に
     先頭のコマンドを選ぶ決定的挙動）では展開の分散が潰れてしまうため、
-    対戦相手やベースラインとしてこのクラスを使うとよい。
+    対戦相手やベースラインとしてこのクラスを使うとよい。選出も
+    `Player.choose_selection()`（先頭から順に選出）の代わりにランダムに選ぶ。
     """
+
+    def choose_selection(self, battle: Battle) -> list[int]:
+        """選出可能な `battle.n_selected` 匹を `battle.decision_random` でランダムに選ぶ。"""
+        return battle.decision_random.sample(range(len(self.team)), battle.n_selected)
 
     def choose_command(self, battle: Battle) -> Command:
         """利用可能なコマンドから `battle.decision_random` でランダムに1つ選ぶ。"""

--- a/src/jpoke/players/tree_search_player.py
+++ b/src/jpoke/players/tree_search_player.py
@@ -122,10 +122,12 @@ class TreeSearchPlayer(Player):
             if not my_commands or not opp_commands:
                 return self.fallback(battle), float("nan")
         else:
-            # 2手目以降
-            # TODO: battle.available_action_commands()を提供する。
-            my_commands = battle.command_manager.available_action_commands(self)
-            opp_commands = battle.command_manager.available_action_commands(opponent)
+            # 2手目以降。sim.step()完了直後の全知シミュレーションかつ新規ターン開始
+            # 直後（中断的な交代は再入した choose_command 側のfallbackで既に解決済み）
+            # であるため、phaseは必ず"action"であり、battle.available_commands()の
+            # phase分岐に委ねてよい。
+            my_commands = battle.available_commands(self)
+            opp_commands = battle.available_commands(opponent)
             battle.player_states[self].required_command_type = "any"
             battle.player_states[opponent].required_command_type = "any"
 
@@ -222,13 +224,13 @@ class TreeSearchPlayer(Player):
             if self._node_limit_reached():
                 break
 
-            # TODO: Battle.copyに全知化するオプションを追加すれば、コピー後にobserverをNoneにする必要はなくなる。
-            sim = battle.copy(reseed=True, copy_logs=False)
-            sim.observer = None
+            sim = battle.copy(reseed=True, copy_logs=False, omniscient=True)
 
             # 探索専用の決定論化オプション（例: 命中固定・平均ダメージ）を
             # sim にだけ設定する。実盤面（battle）には影響しない。
-            # TODO: configure_simは最上位であるchoose_command()内で一度だけ呼ぶほうがよいのでは。
+            # 分岐（sim）ごとに新規オブジェクトのため、choose_command()側で
+            # 1度だけ呼んでも各simには伝播しない。分岐ごとの呼び出しが必須
+            # （test_configure_simが各分岐でsim_step実行前に呼ばれる で担保）。
             self.configure_sim(sim)
 
             # コマンドを指定して盤面を進める。

--- a/tests/test_random_player.py
+++ b/tests/test_random_player.py
@@ -1,0 +1,60 @@
+"""jpoke.players.RandomPlayer の単体テスト。"""
+from jpoke import Battle, Pokemon
+from jpoke.players import RandomPlayer
+
+def _make_team() -> list[Pokemon]:
+    return [
+        Pokemon("ヒトカゲ", item_name="", move_names=["たいあたり"]),
+        Pokemon("ゼニガメ", item_name="", move_names=["たいあたり"]),
+        Pokemon("フシギダネ", item_name="", move_names=["たいあたり"]),
+        Pokemon("ポッポ", item_name="", move_names=["たいあたり"]),
+        Pokemon("コラッタ", item_name="", move_names=["たいあたり"]),
+    ]
+
+
+def test_choose_selectionが同じシードなら同じ選出を返す():
+    player1 = RandomPlayer(username="RandomPlayer1")
+    player1.team = _make_team()
+
+    player2 = RandomPlayer(username="RandomPlayer2")
+    player2.team = _make_team()
+
+    battle1 = Battle(player1, player2, n_selected=3, seed=42)
+    battle2 = Battle(player1, player2, n_selected=3, seed=42)
+
+    assert player1.choose_selection(battle1) == player1.choose_selection(battle2)
+
+
+def test_choose_selectionが常に先頭からの選出にはならない():
+    """RandomPlayer化前のPlayer既定実装（先頭から順に選出）と異なり、
+    複数シードで試せば選出順が固定されないことを確認する。
+    """
+    player1 = RandomPlayer(username="RandomPlayer1")
+    player1.team = _make_team()
+
+    player2 = RandomPlayer(username="RandomPlayer2")
+    player2.team = _make_team()
+
+    default_selection = list(range(3))
+    selections = set()
+    for seed in range(20):
+        battle = Battle(player1, player2, n_selected=3, seed=seed)
+        selections.add(tuple(player1.choose_selection(battle)))
+
+    assert selections != {tuple(default_selection)}
+
+
+def test_choose_selectionが選出数と重複のない有効なインデックスを返す():
+    player1 = RandomPlayer(username="RandomPlayer1")
+    player1.team = _make_team()
+
+    player2 = RandomPlayer(username="RandomPlayer2")
+    player2.team = _make_team()
+
+    battle = Battle(player1, player2, n_selected=3, seed=1)
+
+    indexes = player1.choose_selection(battle)
+
+    assert len(indexes) == battle.n_selected
+    assert len(set(indexes)) == len(indexes)
+    assert all(0 <= i < len(player1.team) for i in indexes)


### PR DESCRIPTION
## Summary
- `RandomPlayer.choose_selection()` を追加し、選出もランダムにする
- `Battle.copy(omniscient=True)` を追加し、`TreeSearchPlayer` が `sim.observer = None` を手動設定していた箇所を置き換える
- `TreeSearchPlayer._best_command()` の2手目以降で `battle.command_manager` を直接呼んでいた箇所を `battle.available_commands()` 経由に変更
- `configure_sim` が各分岐で呼ばれる設計は既存テストで担保済みの意図的な挙動であることを明記し、該当TODOコメントを解消

見送り（設計判断が必要な提案コメントのため、TODOのまま残した）:
- `estimate_opponent` フックの項目別分割案
- 相手コマンド既知時にも `estimate_opponent` を呼び続ける案
- 自分のコマンドスコア計算の汎用関数化案
- `evaluate_commands()` と `_best_command()` の共通化案

## Test plan
- [x] `python -m pytest tests/test_random_player.py -v` — 新規3件PASSED
- [x] `python -m pytest tests/ -q` — 6117 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)