### PR TITLE
feat: レギュレーション別のポケモン・アイテム一覧取得API追加

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -655,12 +655,28 @@ print(mon.types, mon.stats)
 |---|---|
 | `POKEDEX[name].abilities` | そのポケモンが持てる特性のリスト（通常特性1・2・隠れ特性の順）。持てる特性が1つや2つしかないポケモンでは、存在しない枠は含まれず短いリストになる |
 | `POKEDEX[name].learnset` | そのポケモンが覚えられる技のリスト（`list[MoveName]`、五十音順にソート済み） |
+| `POKEDEX[name].regulations` | そのポケモンが使用可能なレギュレーションの集合（`set[Regulation]`） |
 
 ```python
 from jpoke.data import POKEDEX
 
 print(POKEDEX["ピカチュウ"].abilities)          # 持てる特性（通常特性1・2・隠れ特性の順）
 print(len(POKEDEX["ピカチュウ"].learnset))       # 覚えられる技の総数
+print(POKEDEX["ピカチュウ"].regulations)         # 使用可能なレギュレーション
+```
+
+### レギュレーション別の一覧取得
+
+`jpoke.get_pokemon_by_regulation()` / `jpoke.get_items_by_regulation()`。指定した
+レギュレーション（`Regulation`）で使用可能なポケモン名・アイテム名の一覧を、
+`POKEDEX` / `ITEMS` 全件から逆引きで取得する。戻り値はいずれも五十音順にソート済みの
+`list`。
+
+```python
+from jpoke import get_pokemon_by_regulation, get_items_by_regulation
+
+pokemon_list = get_pokemon_by_regulation("M-A")   # -> list[PokemonName]（五十音順）
+item_list = get_items_by_regulation("M-A")        # -> list[ItemName]（五十音順）
 ```
 
 ## Command

--- a/examples/04_others/pokedex.ipynb
+++ b/examples/04_others/pokedex.ipynb
@@ -68,6 +68,20 @@
     "print(f\"覚える技: {dex.learnset[:10]}\") # 最初の10個だけ表示\n",
     "print(f\"対応レギュレーション: {dex.regulations}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "167cdc2b",
+   "source": "あるレギュレーションに該当するポケモン・アイテムの一覧を取得したい場合は、\n`get_pokemon_by_regulation()` / `get_items_by_regulation()` を使う（戻り値は五十音順）。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "87890d21",
+   "source": "from jpoke import get_pokemon_by_regulation, get_items_by_regulation\n\npokemon_list = get_pokemon_by_regulation(\"M-A\")\nitem_list = get_items_by_regulation(\"M-A\")\n\nprint(f\"M-Aで使用可能なポケモン数: {len(pokemon_list)}\")\nprint(f\"M-Aで使用可能なアイテム数: {len(item_list)}\")\nprint(f\"先頭5件（ポケモン）: {pokemon_list[:5]}\")\nprint(f\"先頭5件（アイテム）: {item_list[:5]}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/src/jpoke/__init__.py
+++ b/src/jpoke/__init__.py
@@ -6,7 +6,7 @@
 from .core import Battle, Player
 from .enums import Command
 from .model import Pokemon, Ability, Item, Move
-from .data import POKEDEX
+from .data import POKEDEX, get_pokemon_by_regulation, get_items_by_regulation
 from .utils import get_pokeapi_url, get_pokemon_image_url, get_item_image_url
 
 # pyproject.toml の version と手動で一致させること（tests/test_version.py で検証）
@@ -21,6 +21,8 @@ __all__ = [
     "Item",
     "Move",
     "POKEDEX",
+    "get_pokemon_by_regulation",
+    "get_items_by_regulation",
     "get_pokeapi_url",
     "get_pokemon_image_url",
     "get_item_image_url",

--- a/src/jpoke/data/__init__.py
+++ b/src/jpoke/data/__init__.py
@@ -1,11 +1,11 @@
 from .type_chart import TYPE_MODIFIER, TYPES
 from .nature import NATURES, NATURE_MODIFIER
 from .ability import ABILITIES
-from .item import ITEMS
+from .item import ITEMS, get_items_by_regulation
 from .move import MOVES
 from .field import FIELDS, WEATHER_PRIORITY
 from .ailment import AILMENTS
 from .volatile import VOLATILES
-from .pokedex import POKEDEX
+from .pokedex import POKEDEX, get_pokemon_by_regulation
 from .megaevol import MEGA_STONES, MEGA_POKEMONS
 from .signature_items import PLATE_TO_TYPE, MEMORY_TO_TYPE

--- a/src/jpoke/data/item.py
+++ b/src/jpoke/data/item.py
@@ -2309,3 +2309,8 @@ ITEMS: dict[ItemName, ItemData] = {
 }
 
 common_setup()
+
+
+def get_items_by_regulation(regulation: Regulation) -> list[ItemName]:
+    """指定レギュレーションで使用可能なアイテム名の一覧を返す（五十音順）。"""
+    return sorted(name for name, data in ITEMS.items() if regulation in data.regulations)

--- a/src/jpoke/data/pokedex.py
+++ b/src/jpoke/data/pokedex.py
@@ -56,3 +56,8 @@ for name in pokemon_regulations:
 
 for name in POKEDEX:
     POKEDEX[name].regulations = set(pokemon_regulations.get(name, set()))
+
+
+def get_pokemon_by_regulation(regulation: Regulation) -> list[PokemonName]:
+    """指定レギュレーションで使用可能なポケモン名の一覧を返す（五十音順）。"""
+    return sorted(name for name, data in POKEDEX.items() if regulation in data.regulations)

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -9,47 +9,32 @@ from typing import get_args
 
 import pytest
 
-from jpoke.data import ABILITIES, MOVES, POKEDEX
+from jpoke.data import ABILITIES, MOVES, POKEDEX, get_items_by_regulation, get_pokemon_by_regulation
 from jpoke.data.item import ITEMS
 from jpoke.model.pokemon import Pokemon
-from jpoke.types import AbilityFlag, MoveFlag
+from jpoke.types import AbilityFlag, MoveFlag, Regulation
 
 
-def test_技データ_flagsが全てMoveFlagに定義されている():
-    """MOVES の flags に MoveFlag（types/literals.py）未定義の文字列がないことを確認する。"""
-    valid = set(get_args(MoveFlag))
-    errors = []
-    for name, data in MOVES.items():
-        unknown = set(data.flags) - valid
-        if unknown:
-            errors.append(f"{name}: {sorted(unknown)}")
-    assert not errors, "MoveFlag に未定義のフラグ:\n" + "\n".join(errors)
-
-
-def test_技データ_no_effect_in_singlesの技はPokemonのlearnsetから除外される():
-    """no_effect_in_singlesフラグを持つ技（味方専用で対象不在・公式無効果技等）が、
-    Pokemon.learnset（実戦で使う覚えられる技の集合）に一切含まれないことを確認する。
+def test_get_items_by_regulation_がITEMSのregulationsと一致する():
+    """get_items_by_regulation() が ITEMS を regulations でフィルタした結果と一致し、
+    五十音順にソートされていることを確認する。
     """
-    no_effect_moves = {name for name, data in MOVES.items() if "no_effect_in_singles" in data.flags}
-    assert no_effect_moves, "no_effect_in_singlesフラグを持つ技が1件も無い（フラグ定義の確認漏れ）"
-
-    errors = []
-    for name in POKEDEX:
-        leaked = Pokemon(name).learnset & no_effect_moves
-        if leaked:
-            errors.append(f"{name}: {sorted(leaked)}")
-    assert not errors, "learnsetから除外されていない技:\n" + "\n".join(errors)
+    for regulation in get_args(Regulation):
+        expected = sorted(name for name, data in ITEMS.items() if regulation in data.regulations)
+        actual = get_items_by_regulation(regulation)
+        assert actual == expected, f"{regulation}: actual={actual}, expected={expected}"
+        assert actual, f"{regulation} に該当するアイテムが1件も無い"
 
 
-def test_特性データ_flagsが全てAbilityFlagに定義されている():
-    """ABILITIES の flags に AbilityFlag（types/literals.py）未定義の文字列がないことを確認する。"""
-    valid = set(get_args(AbilityFlag))
-    errors = []
-    for name, data in ABILITIES.items():
-        unknown = set(data.flags) - valid
-        if unknown:
-            errors.append(f"{name}: {sorted(unknown)}")
-    assert not errors, "AbilityFlag に未定義のフラグ:\n" + "\n".join(errors)
+def test_get_pokemon_by_regulation_がPOKEDEXのregulationsと一致する():
+    """get_pokemon_by_regulation() が POKEDEX を regulations でフィルタした結果と一致し、
+    五十音順にソートされていることを確認する。
+    """
+    for regulation in get_args(Regulation):
+        expected = sorted(name for name, data in POKEDEX.items() if regulation in data.regulations)
+        actual = get_pokemon_by_regulation(regulation)
+        assert actual == expected, f"{regulation}: actual={actual}, expected={expected}"
+        assert actual, f"{regulation} に該当するポケモンが1件も無い"
 
 
 def test_アイテムのレギュレーションCSVがITEMSへ反映される():
@@ -124,6 +109,43 @@ def test_ポケモンのレギュレーションCSVがPOKEDEXへ反映される(
             errors.append(f"{name}: actual={sorted(actual)}, expected={sorted(expected_regulations)}")
 
     assert not errors, "PokemonData.regulations と regulation/pokemon.csv が一致しません:\n" + "\n".join(errors)
+
+
+def test_技データ_flagsが全てMoveFlagに定義されている():
+    """MOVES の flags に MoveFlag（types/literals.py）未定義の文字列がないことを確認する。"""
+    valid = set(get_args(MoveFlag))
+    errors = []
+    for name, data in MOVES.items():
+        unknown = set(data.flags) - valid
+        if unknown:
+            errors.append(f"{name}: {sorted(unknown)}")
+    assert not errors, "MoveFlag に未定義のフラグ:\n" + "\n".join(errors)
+
+
+def test_技データ_no_effect_in_singlesの技はPokemonのlearnsetから除外される():
+    """no_effect_in_singlesフラグを持つ技（味方専用で対象不在・公式無効果技等）が、
+    Pokemon.learnset（実戦で使う覚えられる技の集合）に一切含まれないことを確認する。
+    """
+    no_effect_moves = {name for name, data in MOVES.items() if "no_effect_in_singles" in data.flags}
+    assert no_effect_moves, "no_effect_in_singlesフラグを持つ技が1件も無い（フラグ定義の確認漏れ）"
+
+    errors = []
+    for name in POKEDEX:
+        leaked = Pokemon(name).learnset & no_effect_moves
+        if leaked:
+            errors.append(f"{name}: {sorted(leaked)}")
+    assert not errors, "learnsetから除外されていない技:\n" + "\n".join(errors)
+
+
+def test_特性データ_flagsが全てAbilityFlagに定義されている():
+    """ABILITIES の flags に AbilityFlag（types/literals.py）未定義の文字列がないことを確認する。"""
+    valid = set(get_args(AbilityFlag))
+    errors = []
+    for name, data in ABILITIES.items():
+        unknown = set(data.flags) - valid
+        if unknown:
+            errors.append(f"{name}: {sorted(unknown)}")
+    assert not errors, "AbilityFlag に未定義のフラグ:\n" + "\n".join(errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `get_pokemon_by_regulation(regulation)` / `get_items_by_regulation(regulation)` を追加し、指定レギュレーションに該当するポケモン名・アイテム名の一覧（五十音順）を `POKEDEX` / `ITEMS` から逆引きできるようにした
- `jpoke` トップレベルおよび `jpoke.data` から再エクスポート
- `docs/api/README.md` に使用方法を追記、`examples/04_others/pokedex.ipynb` に使用例セルを追加

## Test plan
- [x] `python -m pytest tests/ -v` 全件パス（6124 passed, 1 skipped）
- [x] `tests/test_data_integrity.py` に新規テストを追加し、CSVベースの期待値と関数の戻り値の一致・ソート順・非空を検証
- [x] `examples/04_others/pokedex.ipynb` を papermill で実行し、追加セルがエラーなく実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)