### PR TITLE
docs(examples): Colabインストール手順の冒頭説明文を削除

### DIFF
--- a/examples/03_lethal/05_testing_helpers.ipynb
+++ b/examples/03_lethal/05_testing_helpers.ipynb
@@ -13,19 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# jpoke.testing のヘルパーを使い、これまでのサンプルで繰り返し書いてきた\n",
-    "Battle(...).start() + Player.add_pokemon() の定型処理を1呼び出しにまとめる方法を示す\n",
-    "\n",
-    "jpoke.testing の位置づけ（内部テスト専用ヘルパーからの昇格）・提供するヘルパー一覧は\n",
-    "docs/api/README.md の テストユーティリティ（jpoke.testing）節を参照。\n",
-    "「状態を変えて比較する」シナリオ検証コードが短く書けるようになる。\n",
-    "\n",
-    "Google Colabで開いた場合は、まず次のセルで `jpoke` をインストールする\n",
-    "（ローカルで `pip install jpoke` 済みなら不要）。\n",
-    "\n",
-    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/03_lethal/05_testing_helpers.ipynb)"
-   ]
+   "source": "# jpoke.testing のヘルパーを使い、これまでのサンプルで繰り返し書いてきた\nBattle(...).start() + Player.add_pokemon() の定型処理を1呼び出しにまとめる方法を示す\n\njpoke.testing の位置づけ（内部テスト専用ヘルパーからの昇格）・提供するヘルパー一覧は\ndocs/api/README.md の テストユーティリティ（jpoke.testing）節を参照。\n「状態を変えて比較する」シナリオ検証コードが短く書けるようになる。\n\n[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/03_lethal/05_testing_helpers.ipynb)"
   },
   {
    "cell_type": "code",

--- a/examples/04_others/logcode.ipynb
+++ b/examples/04_others/logcode.ipynb
@@ -4,20 +4,7 @@
    "cell_type": "markdown",
    "id": "4fddcca5",
    "metadata": {},
-   "source": [
-    "# LogCode の種類を確認する\n",
-    "\n",
-    "LogCode の種類を確認する方法を扱う。\n",
-    "\n",
-    "`print_logs()` / `get_log_lines()` は表示用に文字列化済みのログだが、プログラムで\n",
-    "特定の種類のイベントだけを集計・抽出したい場合は `battle.get_event_logs(turn)` が\n",
-    "返す LogCode 付きの EventLog を見る。\n",
-    "\n",
-    "Google Colabで開いた場合は、まず次のセルで `jpoke` をインストールする\n",
-    "（ローカルで `pip install jpoke` 済みなら不要）。\n",
-    "\n",
-    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/logcode.ipynb)"
-   ]
+   "source": "# LogCode の種類を確認する\n\nLogCode の種類を確認する方法を扱う。\n\n`print_logs()` / `get_log_lines()` は表示用に文字列化済みのログだが、プログラムで\n特定の種類のイベントだけを集計・抽出したい場合は `battle.get_event_logs(turn)` が\n返す LogCode 付きの EventLog を見る。\n\n[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/logcode.ipynb)"
   },
   {
    "cell_type": "code",

--- a/examples/04_others/poke_env_style_player.ipynb
+++ b/examples/04_others/poke_env_style_player.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "id": "749a554d",
    "metadata": {},
-   "source": [
-    "# poke-env経験者向け: poke-env互換プロパティ・APIを使った choose_command() の実装方法を示す\n",
-    "\n",
-    "01_getting_started/03_custom_player.ipynb の CustomePlayer は available_commands() +\n",
-    "command_to_move() の組み合わせで実装していたが、poke-env互換プロパティ・\n",
-    "create_order()とpoke-envのBattleOrderとの違いは docs/api/README.md の\n",
-    "Battle「poke-env互換プロパティ」節・create_order()の項を参照。\n",
-    "\n",
-    "Google Colabで開いた場合は、まず次のセルで `jpoke` をインストールする\n",
-    "（ローカルで `pip install jpoke` 済みなら不要）。\n",
-    "\n",
-    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/poke_env_style_player.ipynb)"
-   ]
+   "source": "# poke-env経験者向け: poke-env互換プロパティ・APIを使った choose_command() の実装方法を示す\n\n01_getting_started/03_custom_player.ipynb の CustomePlayer は available_commands() +\ncommand_to_move() の組み合わせで実装していたが、poke-env互換プロパティ・\ncreate_order()とpoke-envのBattleOrderとの違いは docs/api/README.md の\nBattle「poke-env互換プロパティ」節・create_order()の項を参照。\n\n[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/poke_env_style_player.ipynb)"
   },
   {
    "cell_type": "code",

--- a/examples/05_advanced/01_bulk_simulation.ipynb
+++ b/examples/05_advanced/01_bulk_simulation.ipynb
@@ -4,18 +4,7 @@
    "cell_type": "markdown",
    "id": "3944321f",
    "metadata": {},
-   "source": [
-    "# Player.battle_against() を使い、多数回対戦させて構成を比較する\n",
-    "\n",
-    "同じポケモンでアイテムだけを変えた2つの構成を、共通の対戦相手と多数回戦わせて\n",
-    "勝率を比較する。poke-env 互換 API（battle_against）を使った、戦術研究ユースケース\n",
-    "（構成比較）の入口。\n",
-    "\n",
-    "Google Colabで開いた場合は、まず次のセルで `jpoke` をインストールする\n",
-    "（ローカルで `pip install jpoke` 済みなら不要）。\n",
-    "\n",
-    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/05_advanced/01_bulk_simulation.ipynb)"
-   ]
+   "source": "# Player.battle_against() を使い、多数回対戦させて構成を比較する\n\n同じポケモンでアイテムだけを変えた2つの構成を、共通の対戦相手と多数回戦わせて\n勝率を比較する。poke-env 互換 API（battle_against）を使った、戦術研究ユースケース\n（構成比較）の入口。\n\n[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/05_advanced/01_bulk_simulation.ipynb)"
   },
   {
    "cell_type": "code",

--- a/examples/05_advanced/02_replay.ipynb
+++ b/examples/05_advanced/02_replay.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "id": "7e89e679",
    "metadata": {},
-   "source": [
-    "# 対戦の記録・再生（リプレイ）機能一式を扱う\n",
-    "\n",
-    "対戦を最後まで進めて `Battle.build_replay_data()` で対戦の記録を取り、`replay_battle()`\n",
-    "でその記録から同じ展開の対戦をそのまま再生する（`ReplayPlayer` 等の詳細は\n",
-    "docs/api/README.md の リプレイ系 節を参照）。「興味深い対戦を記録して後で解析する」\n",
-    "という戦術研究ユースケースの入口。\n",
-    "\n",
-    "Google Colabで開いた場合は、まず次のセルで `jpoke` をインストールする\n",
-    "（ローカルで `pip install jpoke` 済みなら不要）。\n",
-    "\n",
-    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/05_advanced/02_replay.ipynb)"
-   ]
+   "source": "# 対戦の記録・再生（リプレイ）機能一式を扱う\n\n対戦を最後まで進めて `Battle.build_replay_data()` で対戦の記録を取り、`replay_battle()`\nでその記録から同じ展開の対戦をそのまま再生する（`ReplayPlayer` 等の詳細は\ndocs/api/README.md の リプレイ系 節を参照）。「興味深い対戦を記録して後で解析する」\nという戦術研究ユースケースの入口。\n\n[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/05_advanced/02_replay.ipynb)"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- 各exampleノートブック冒頭の「Google Colabで開いた場合は...インストールする」の一文を削除
- Colabで開くリンクが既にあるため、重複する説明として不要と判断

## Test plan
- ドキュメント文言の削除のみ（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)