### PR TITLE
refactor(testing): fix_damage/fix_randomを公開APIから除外

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -839,8 +839,9 @@ move.modify_pp(-99)  # PPを0にする（わるあがきを誘発させたい場
 昇格したもので、`pip install jpoke` だけで（`jpoke` リポジトリを clone せずに）
 ピンポイントな状態検証・技の実行・行動順の確認などができる。
 
-`fix_damage()` / `fix_random()` は `Battle` の内部属性を直接差し替えるモンキーパッチの
-デバッグ用ユーティリティであり、本番の対戦進行（bot 運用等）では使わないこと。
+対戦オブジェクトの内部属性を直接差し替えるモンキーパッチ（ダメージ・乱数固定用の
+`fix_damage()` / `fix_random()` など）はAPI安定性の対象外とするため含めていない。
+リポジトリ内のテストで使う場合は `tests/test_utils.py` を参照。
 
 ```python
 from jpoke import Pokemon
@@ -878,8 +879,6 @@ print(results[-1].lethal_probability)
 | `calc_lethal(battle, player_idx, moves, critical=False, secondary=False, max_attack=10)` | `Battle.calc_lethal()` のインデックス指定版 |
 | `calc_move_priority(battle, player_idx, move_index=0)` | 指定インデックスの技を使ったときの優先度を返す。`Battle.calc_move_priority(pokemon, move)` のインデックス指定版 |
 | `end_turn(battle)` | `Battle.end_turn()` のラッパー |
-| `fix_damage(battle, damage)` | ダメージ計算を固定値にする（デバッグ専用モンキーパッチ） |
-| `fix_random(battle, value)` | `battle.random.random()` を固定値にする（デバッグ専用モンキーパッチ） |
 | `CustomPlayer` | 常に利用可能な最初のコマンドを選択する `Player` 実装。上記ヘルパーの内部で使われる |
 
 ## 関連リンク

--- a/src/jpoke/testing.py
+++ b/src/jpoke/testing.py
@@ -4,9 +4,10 @@
 `pip install jpoke` だけで（`jpoke` リポジトリを clone せずに）任意ターンでの
 ピンポイントな状態検証・技の実行・行動順の確認などができる。
 
-外部から使う関数の多くは `Battle` / `Pokemon` の公開メソッドのみに依存している。
-ただし `fix_damage` / `fix_random` は対戦オブジェクトの内部属性を直接差し替える
-デバッグ用のモンキーパッチであり、本番の対戦進行（bot 運用等）では使わないこと。
+ここに含まれる関数は全て `Battle` / `Pokemon` の公開メソッドのみに依存している。
+対戦オブジェクトの内部属性を直接差し替えるモンキーパッチ（ダメージ・乱数固定など）
+は本体パッケージのAPI安定性の対象外とするため含めていない。リポジトリ内のテストで
+使う `fix_damage` / `fix_random` は `tests/test_utils.py` を参照。
 """
 from jpoke.core import Battle, Player, AttackContext
 from jpoke.core.lethal import LethalHitResult
@@ -27,8 +28,6 @@ __all__ = [
     "end_turn",
     "apply_ailment",
     "get_action_order",
-    "fix_damage",
-    "fix_random",
     "calc_lethal",
     "calc_move_priority",
 ]
@@ -317,35 +316,6 @@ def get_action_order(battle: Battle,
     """
     reserve_command(battle, command0, command1)
     return battle.resolve_action_order()
-
-
-def fix_damage(battle: Battle, damage: int):
-    """ダメージ計算のダイスロールを固定値にする。
-
-    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
-    `Battle.roll_damage` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
-    ダメージ計算は全て固定値になる。
-
-    Args:
-        battle: Battleインスタンス
-        damage: 固定するダメージ値
-    """
-    battle.roll_damage = lambda *args, **kwargs: damage
-
-
-def fix_random(battle: Battle, value: float):
-    """乱数を固定する。
-
-    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
-    `Battle.random.random` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
-    `random()` 呼び出しは全て固定値になる（`choice`/`randint`/`shuffle`等の他のメソッドには
-    効果がない点に注意）。
-
-    Args:
-        battle: Battleインスタンス
-        value: 固定する乱数の値（0.0以上1.0未満）
-    """
-    battle.random.random = lambda: value
 
 
 def calc_lethal(battle: Battle,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,16 @@
 """テストヘルパーの薄い再エクスポート層。
 
-実体は `jpoke.testing`（本体パッケージへ昇格済み）に移設した。既存テストコードの
+大半の実体は `jpoke.testing`（本体パッケージへ昇格済み）に移設した。既存テストコードの
 `from . import test_utils as t` / `from .. import test_utils as t` という参照パターンを
 壊さないための後方互換シムとして残している。新規コードは `jpoke.testing` を直接
 参照してよい。
+
+`fix_damage` / `fix_random` は対戦オブジェクトの内部属性を直接差し替えるデバッグ用
+モンキーパッチであり、本番の対戦進行（bot 運用等）では使わないこと。`jpoke.testing`
+はAPI安定性が求められる公開パッケージのため、この2つはリポジトリ内テスト専用として
+本ファイルにのみ実装する。
 """
+from jpoke import Battle
 from jpoke.testing import (
     CustomPlayer,
     start_battle,
@@ -17,8 +23,6 @@ from jpoke.testing import (
     end_turn,
     apply_ailment,
     get_action_order,
-    fix_damage,
-    fix_random,
     calc_lethal,
     calc_move_priority,
 )
@@ -40,3 +44,32 @@ __all__ = [
     "calc_lethal",
     "calc_move_priority",
 ]
+
+
+def fix_damage(battle: Battle, damage: int):
+    """ダメージ計算のダイスロールを固定値にする。
+
+    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
+    `Battle.roll_damage` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
+    ダメージ計算は全て固定値になる。
+
+    Args:
+        battle: Battleインスタンス
+        damage: 固定するダメージ値
+    """
+    battle.roll_damage = lambda *args, **kwargs: damage
+
+
+def fix_random(battle: Battle, value: float):
+    """乱数を固定する。
+
+    テスト・デバッグ専用のユーティリティであり、本番の対戦進行では使わないこと。
+    `Battle.random.random` を差し替えるモンキーパッチのため、以降そのBattleインスタンスの
+    `random()` 呼び出しは全て固定値になる（`choice`/`randint`/`shuffle`等の他のメソッドには
+    効果がない点に注意）。
+
+    Args:
+        battle: Battleインスタンス
+        value: 固定する乱数の値（0.0以上1.0未満）
+    """
+    battle.random.random = lambda: value


### PR DESCRIPTION
## Summary
- `jpoke.testing`（`pip install jpoke`で配布される公開パッケージ）から `fix_damage()` / `fix_random()` を除外
- 内部属性（`Battle.roll_damage` / `battle.random.random`）を直接差し替えるモンキーパッチであり、公開APIとして安定性を保証する対象にそぐわないため
- 実体は `tests/test_utils.py`（リポジトリ内テスト専用）へ移設
- `docs/api/README.md` の該当記述も更新

## Test plan
- [x] `python -m pytest tests/ -q` — 6124 passed, 1 skipped