### PR TITLE
docs: poke-env比較レビューを踏まえたドキュメント構造の整理

### DIFF
--- a/.internal/plan/docs_structure_review.md
+++ b/.internal/plan/docs_structure_review.md
@@ -1,0 +1,111 @@
+# 計画: ドキュメント構造の見直し（poke-env比較レビュー）
+
+更新日: 2026-07-21
+
+## 背景
+
+ユーザー依頼: 「poke-envの導入ドキュメントは非常にわかりやすい。参考にして、jpokeの
+ドキュメントの構造をレビューせよ」。poke-env公式ドキュメント（`.internal/poke-env/api_reference/`
+にキャッシュ済みのHTML）とjpoke側の`README.md` / `CONTRIBUTING.md` / `docs/` /
+`examples/` を比較した結果を、このレビュー会話のレポートとして本ファイルに記録し、
+指摘事項のうち合意が得られたものを本ブランチで実施する。
+
+## poke-envの構造（参考にした点）
+
+Sphinxベースの3階層構成。どのページからでも同一のサイドバーツリーが表示され、
+迷わない。
+
+1. **User guide**: 「Getting Started」（インストール→ローカルサーバー起動→
+   実際に動いて出力が出る最小サンプル→エージェント作成へのリンク集→接続設定→
+   "What Next"で次の一手を提示）と「Examples」（一覧ページ＋積み上げ式の
+   Quickstartノートブック。実行済みセル番号[1][2][3]…と出力がサイト内に
+   埋め込まれている）
+2. **Main modules documentation**: `Battle`/`Player`/`Pokemon`/`Move`等、
+   ドメインオブジェクトごとに1ページ。docstringからの自動生成のみ（手書きの
+   並行リファレンスは持たない）
+3. **Standalone submodules documentation**: `Data`/`PS Client`/`Teambuilder`等の
+   ユーティリティ系を上記と明確に分離
+
+## jpokeの現状構造との対応
+
+| poke-env | jpoke |
+|---|---|
+| Getting Started（独立ページ） | 無し。`README.md`（`docs/index.md`が`include-markdown`で丸ごと取り込み）が兼務 |
+| Examples（一覧＋積み上げ式Quickstart、サイト内で実行結果を閲覧可） | `examples/README.md`（一覧、各`.ipynb`はGoogle Colabバッジ経由でワンクリック実行） |
+| Main/Standalone modules（自動生成のみ） | `docs/api/README.md`（手書き890行）＋`docs/reference/*.md`（mkdocstrings自動生成）の二重構成 |
+| CONTRIBUTING（開発者向けを分離） | `CONTRIBUTING.md`はあるが`README.md`と内容重複 |
+
+## 所見（優先度順、および見送り事項）
+
+1. **`README.md`が利用者向け/貢献者向け情報を1ページに混在**（246行）。
+   インストール→クイックスタート→アーキテクチャ→ドキュメント地図→実装状況→
+   計算速度ベンチマーク→テストヘルパー→開発セットアップ→テスト実行→
+   開発ツール→ライセンス、と一枚に積み上がっている。
+2. **`README.md`と`CONTRIBUTING.md`の内容重複**。`README.md`の「開発
+   （clone前提）」「テストの実行」「開発ツール」節が`CONTRIBUTING.md`の
+   「開発環境のセットアップ」「テストの実行」「コードスタイル」節とほぼ
+   同一テキストで存在し、`docs/index.md`・`docs/contributing.md`双方が
+   `include-markdown`でそのまま公開されるため、片方だけ更新されて
+   食い違うドリフトリスクがある。
+3. **APIリファレンスの二重構成**（`docs/api/README.md`手書き890行 +
+   `docs/reference/*.md`自動生成）。`docs/reference/index.md`で役割の説明は
+   あるが、`docs/api/README.md`自体の冒頭には簡潔な相互参照はあるものの
+   十分に目立たない。なお本構成自体は`.internal/plan/notebook_examples.md`
+   （notebook化プロジェクト）で「examplesのAPI仕様説明を`docs/api/README.md`に
+   統合する」という意図的な設計判断として導入された経緯があり、内容を
+   薄める対象ではなく**役割分担の明示を強化する**対応にとどめる。
+4. **`examples/04_research/`が空のまま放置**され、`examples/README.md`にも
+   記載が無い（`04_others/`のみ記載）。
+
+### 見送り事項（意図的にpoke-env流を採用しない）
+
+- poke-envはExamplesページ自体にノートブックの実行結果を静的に埋め込んでいるが、
+  jpokeは**Google Colabバッジ経由でその場で実行できる**方式を取っている
+  （`.internal/plan/notebook_examples.md`で意図的に構築済み）。ユーザー確認の
+  結果、**Colab上でその場で動かせる点はjpoke独自の強みであり維持する**。
+  ドキュメントサイト内へのノートブック出力の静的埋め込みは行わない。
+
+## スコープ・対象ファイル
+
+- `examples/04_research/`（削除）
+- `README.md`（開発者向け重複節の整理、`CONTRIBUTING.md`への導線化）
+- `CONTRIBUTING.md`（変更なし。重複解消後の一次情報源として維持）
+- `docs/api/README.md`（冒頭の役割説明を強化）
+- `docs/reference/index.md`（相互参照の追記、必要なら）
+
+## フェーズ
+
+### フェーズ0: 前提
+
+- [x] `feature/docs-restructure`ブランチ・worktree（`jpoke-work/docs-restructure`）を作成
+- [x] 本計画書を作成
+
+### フェーズ1: `examples/04_research/`削除
+
+- [x] 空ディレクトリを削除（`examples/README.md`に記載が無く、`git ls-files`にも
+      現れないため追跡対象外と確認済み）
+
+### フェーズ2: README/CONTRIBUTING.mdの重複解消
+
+- [x] `README.md`の「開発（clone前提）」「テストの実行」「開発ツール」節を、
+      `CONTRIBUTING.md`への短い導線（「開発に貢献する」節）に置き換える
+- [x] `README.md`の他の節（対象範囲・インストール・クイックスタート・
+      アーキテクチャ・ドキュメント地図・実装状況・計算速度・テストヘルパー・
+      ライセンス）はそのまま維持する（GitHub/PyPI/docsサイト共通の
+      ランディングとして必要な内容のため）
+- [x] README側から削った「五十音順チェック（`--check`）コマンド」は
+      `CONTRIBUTING.md`のコードスタイル節に移設し、内容を失わないようにした
+- [x] `tests/test_code_conventions.py`（`README_PATH`を参照する既存テスト）に
+      抵触しないことを確認（10 passed）
+
+### フェーズ3: APIリファレンスの役割分担の明示強化
+
+- [x] `docs/api/README.md`冒頭に、全シグネチャ・全メソッドを網羅した
+      自動生成リファレンス（`docs/reference/index.md`）への明示的なリンクを追記
+- [x] 内容そのもの（890行のプロース解説）は削らない
+
+### フェーズ4: 検証・PR
+
+- [x] `python -m pytest tests/ -v`が通ることを確認（6127 passed, 1 skipped）
+- [x] `python -m ruff check src/ tests/ scripts/ examples/`（All checks passed!）
+- [ ] `gh pr create` → 確認のうえ`gh pr merge`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,20 @@ python -m pytest tests/ -q --cov=jpoke --cov-report=term
   python -m mypy
   ```
 
+- 五十音順の維持・データ整合性チェック（`--check` は変更せず確認のみ）:
+
+  ```bash
+  python scripts/sort_handlers.py --check
+  python scripts/sort_data/sort_abilities.py --check
+  python scripts/sort_data/sort_items.py --check
+  python scripts/sort_data/sort_moves.py --check
+  python scripts/sort_tests.py --check tests/**/test_*.py
+  ```
+
 `.pre-commit-config.yaml` を使うと、これらのチェック（の一部）をコミット前に
 ローカルで自動実行できます（`pip install pre-commit && pre-commit install`）。
+CI（`.github/workflows/test.yml`）でも push/PR ごとに同等のチェックを
+Windows + Linux × Python 3.11/3.12 のマトリクスで実行しています。
 
 ## バージョン管理
 

--- a/README.md
+++ b/README.md
@@ -172,69 +172,14 @@ t.run_move(battle, player_idx=0, move_idx=0)
 薄い再エクスポート層）で使っている。詳細な使い方は
 [tests/CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/tests/CLAUDE.md) も参照。
 
-## 開発（clone 前提）
+## 開発に貢献する
 
-ソースを直接編集する場合はリポジトリを clone してセットアップする。
-
-```bash
-git clone https://github.com/tmwork1/jpoke.git
-cd jpoke
-pip install -e .
-
-# 開発（テスト・lint・型チェック）に必要な依存を含める場合
-pip install -e . pytest pytest-cov ruff mypy
-# または uv を使う場合
-uv sync
-```
-
-## テストの実行
-
-```bash
-# 全テスト
-python -m pytest tests/ -v
-
-# カテゴリ別
-python -m pytest tests/abilities/ -v
-python -m pytest tests/items/ -v
-python -m pytest tests/moves_attack/ -v
-python -m pytest tests/moves_status/ -v
-python -m pytest tests/volatiles/ -v
-
-# 特定ファイル
-python -m pytest tests/abilities/test_ability_ka.py -v
-
-# 特定テスト関数（日本語関数名も可）
-python -m pytest tests/abilities/ -k "ARシステム" -v
-
-# カバレッジ付き
-python -m pytest tests/ -q --cov=jpoke --cov-report=term
-```
-
-テストは `tests/` 直下（`test_ailment.py`, `test_copy.py`, `test_damage.py`, `test_field.py`,
-`test_lethal.py` など）とサブディレクトリ（`abilities/`, `items/`, `moves_attack/`,
-`moves_status/`, `volatiles/`）に分かれている。`tests/test_utils.py` はテストヘルパー（テスト対象外）。
-
-## 開発ツール
-
-```bash
-# lint
-python -m ruff check src/ tests/ scripts/ examples/
-
-# 型チェック（src/jpoke/core のみを対象に段階導入中）
-python -m mypy
-
-# 五十音順の維持・データ整合性チェック（--check は変更せず確認のみ）
-python scripts/sort_handlers.py --check
-python scripts/sort_data/sort_abilities.py --check
-python scripts/sort_data/sort_items.py --check
-python scripts/sort_data/sort_moves.py --check
-python scripts/sort_tests.py --check tests/**/test_*.py
-```
-
-CI（`.github/workflows/test.yml`）で push/PR ごとに Windows + Linux × Python 3.11/3.12 のマトリクスで
-テスト・lint・型チェックを実行する。`.github/workflows/nightly-fuzz.yml` が毎日 `scripts/fuzz/fuzz_battle.py`
-を random / tree_search の両プレイヤーモデル（`--player`）で実行し、回帰シードを検出する。`.pre-commit-config.yaml` を使うと
-コミット前にこれらのチェック（の一部）をローカルで実行できる。
+ソースを直接編集する場合の環境セットアップ・テストの実行・lintや型チェックなどの
+コード規約は [CONTRIBUTING.md](https://github.com/tmwork1/jpoke/blob/main/CONTRIBUTING.md)
+にまとめている。CI（`.github/workflows/test.yml`）が push/PR ごとに Windows + Linux ×
+Python 3.11/3.12 のマトリクスでテスト・lint・型チェックを実行し、
+`.github/workflows/nightly-fuzz.yml` が毎日 `scripts/fuzz/fuzz_battle.py` を
+random / tree_search の両プレイヤーモデルで実行して回帰シードを検出している。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -172,14 +172,16 @@ t.run_move(battle, player_idx=0, move_idx=0)
 薄い再エクスポート層）で使っている。詳細な使い方は
 [tests/CLAUDE.md](https://github.com/tmwork1/jpoke/blob/main/tests/CLAUDE.md) も参照。
 
-## 開発に貢献する
+## 開発への貢献
 
-ソースを直接編集する場合の環境セットアップ・テストの実行・lintや型チェックなどの
-コード規約は [CONTRIBUTING.md](https://github.com/tmwork1/jpoke/blob/main/CONTRIBUTING.md)
-にまとめている。CI（`.github/workflows/test.yml`）が push/PR ごとに Windows + Linux ×
-Python 3.11/3.12 のマトリクスでテスト・lint・型チェックを実行し、
-`.github/workflows/nightly-fuzz.yml` が毎日 `scripts/fuzz/fuzz_battle.py` を
-random / tree_search の両プレイヤーモデルで実行して回帰シードを検出している。
+ソースを直接編集する場合の環境セットアップ・コード規約は
+[CONTRIBUTING.md](https://github.com/tmwork1/jpoke/blob/main/CONTRIBUTING.md) を参照。
+テストの実行方法もそちらにまとめている。
+
+CIがpush/PRごとに自動でテスト・lint・型チェックを実行している（マトリクス構成の詳細は
+CONTRIBUTING.md参照）。`.github/workflows/nightly-fuzz.yml` が毎日
+`scripts/fuzz/fuzz_battle.py` を random / tree_search の両プレイヤーモデルで実行し、
+回帰シードを検出している。
 
 ## ライセンス
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,7 +12,8 @@
 このドキュメントは **よく使う公開APIの見取り図**であり、全メソッド・全引数を網羅する
 ものではない。詳細な挙動・戻り値・例外条件は各クラスのdocstring（ソースコード:
 `src/jpoke/core/battle.py`, `src/jpoke/core/player.py`, `src/jpoke/model/pokemon.py`）を
-直接参照すること。
+直接参照すること。全シグネチャ・全メソッド・全属性を網羅した自動生成リファレンスは
+[リファレンス（自動生成）](../reference/index.md)を参照。
 
 対象範囲・アーキテクチャの全体像は [README.md](https://github.com/tmwork1/jpoke/blob/main/README.md)
 を参照。


### PR DESCRIPTION
## Summary
- poke-envのドキュメント構造をレビューし、`.internal/plan/docs_structure_review.md` にレビュー結果と方針を文書化
- `README.md` と `CONTRIBUTING.md` で重複していた開発者向け節（clone手順・テスト実行・lint/mypy）を統合し、`README.md` は `CONTRIBUTING.md` への導線に簡略化（削った `--check` コマンドは `CONTRIBUTING.md` に移設）
- `docs/api/README.md` 冒頭に、全シグネチャを網羅する自動生成リファレンス（`docs/reference/`）への明示的なリンクを追加
- 未追跡の空ディレクトリ `examples/04_research/` を削除

Colab経由でノートブックをその場で実行できる現行のexamples構成（poke-envのサイト内埋め込み実行結果表示とは異なる方式）はjpoke独自の強みとして維持し、変更していません。

## Test plan
- [x] `python -m pytest tests/ -v` (6127 passed, 1 skipped)
- [x] `python -m ruff check src/ tests/ scripts/ examples/` (All checks passed!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)