### PR TITLE
poke-envのRL機能調査とjpoke向けRL支援ヘルパーの実装計画

### DIFF
--- a/.internal/plan/poke-env/rl_support.md
+++ b/.internal/plan/poke-env/rl_support.md
@@ -1,0 +1,249 @@
+# 実装計画: RL支援ヘルパー（外部ライブラリ非依存）
+
+更新日: 2026-07-21
+
+## 背景
+
+`.internal/poke-env/rl_features_analysis.md` の調査により、poke-env の主目的が
+「強化学習(RL)ボット訓練用インターフェースの提供」であり、Gymnasium/PettingZoo準拠の
+`PokeEnv`（行動空間・観測空間・報酬シェーピングヘルパー・行動マスク）を持つことを確認した。
+jpoke にはこれに相当する機能がなく、`build_observation()`（部分観測）・`Command` Enum
+（固定順の行動表現）・`Player.battle_against()`（一括対戦）など断片的な下地はあるものの、
+RLを始めるための一貫したAPIは未整備。
+
+**ユーザー方針（2026-07-21確認）: `gymnasium`/`pettingzoo` 等の外部ライブラリは
+`dependencies` に追加しない。** その代わり、RLを始めるのに便利な機能（行動の列挙・
+合法手マスク・観測ベクトル化の参考実装・報酬シェーピングヘルパー・簡易な学習ループ）を
+素の Python だけで提供する。gymnasium 実利用者は本モジュールの戻り値をそのまま
+`gymnasium.Env` の各メソッドの戻り値に流用できる設計とする（アダプタは利用者側の数行で済む）。
+
+## スコープ
+
+- 新規 `src/jpoke/rl.py`（単一ファイル。`types/poke_env.py` 程度の規模を想定）
+- `pyproject.toml` の変更は不要（依存追加なし）
+- 既存の `core/battle.py` / `core/player.py` / `enums/command.py` には手を入れない
+  （RL支援機能は既存APIの上に乗る薄いレイヤーとして実装する）
+
+## 前提として確認済みの既存API
+
+- `Command`（`enums/command.py`）: `SWITCH_0..9` / `MOVE_0..9` / `TERASTAL_0..9` /
+  `MEGAEVOL_0..9` / `GIGAMAX_0..9` / `ZMOVE_0..9` + 特殊コマンド `STRUGGLE`/`FORCED` の
+  固定順 Enum。`Command.names()` で全件、`index`プロパティで枝番、`get_*_command(index)`で逆引き可能。
+- `Battle.available_commands(player) -> list[Command]`（現在選択可能なコマンド列挙。
+  観測者が相手の場合は `player_states[player].last_available_commands` にフォールバックする
+  実装済みの分岐がある）
+- `Battle.build_observation(observer) -> Battle`（部分観測コピー）
+- `Battle.won(player) -> bool` / `lost(player) -> bool` / `finished`（poke-env互換、実装済み）
+- `Battle.step(commands: dict[Player, Command] | None = None)`（`None`なら
+  `resolve_command("action")` が各プレイヤーの `choose_command(build_observation(player))` を
+  呼んで解決する）
+- `Battle.play_out(max_turns)` / `Player.battle_against(*opponents, n_battles, on_battle_end, **battle_kwargs)`
+  （実装済み。一括対戦・戦績集計）
+- `Pokemon.hp_fraction` / `fainted` / `ailment.name`（状態異常の有無判定に使用）
+
+## 設計上の論点（要ユーザー判断 or 実装時に確定させる）
+
+### 論点1: ターン内の複数意思決定点（強制交代）の扱い
+
+`command_manager.resolve_command()` は `phase="action"` の後、瀕死交代・だっしゅつパック等の
+割り込みで `phase="switch"` の解決も必要になった場合、**呼び出し元に制御を戻さず
+`player.choose_command(observation)` を内部で自動的に呼ぶ**（`battle.step()` 一回の中に
+複数の意思決定が埋め込まれうる）。つまり「RL環境の1 `step(action)` 呼び出し = 1回の意思決定」
+という前提が、瀕死交代が絡むターンでは素直に成立しない。
+
+poke-env はこれを「別スレッド + asyncioキュー」で解決している（`_EnvPlayer` が
+`choose_move()` 呼び出しのたびにキューで待機し、外側の同期 `env.step()` がキューに
+行動を積んで解放する）。jpoke でも同じ発想を asyncio なしで（`threading.Thread` +
+`queue.Queue`、いずれも標準ライブラリ）再現することは可能。
+
+**この計画では、まず以下のA案で最小実装し、B案は将来の拡張候補として明記するに留める:**
+
+- **A案（v1・採用）**: 強制交代（瀕死交代等）の意思決定は、学習対象の `Player` の
+  既定 `choose_command()`（先頭のコマンドを選ぶ）にフォールバックさせる。RL行動として
+  外部に公開するのは「通常のaction フェーズの意思決定」のみに限定する。制約として
+  ドキュメントに明記する（瀕死交代の戦略性を学習させたい場合はB案が必要、という注記付き）。
+- **B案（将来拡張）**: `threading.Thread` + `queue.Queue` で `Battle.play_out()` を
+  バックグラウンドスレッドに移し、学習対象 `Player` の `choose_command()` を
+  「キューから行動を受け取るまでブロックする」実装に差し替える。`RLBattleEnv.step(action)`
+  はメインスレッドからキューに行動を積んで結果を待つ。poke-env の `_EnvPlayer`/`_AsyncQueue`
+  と同型だが asyncio 不要（標準ライブラリの`threading`/`queue`のみで完結、外部依存は増えない）。
+
+### 論点2: 観測の型
+
+poke-env の `embed_battle()` は「利用者が実装する」設計（参考実装なし）。jpokeは
+`build_observation()` で部分観測の `Battle` オブジェクトそのものは得られるが、数値配列への
+変換は用途依存性が高い（種族・技をどうエンコードするか等）。本計画では**最小の参考実装
+（HP割合・状態異常有無・ランク変化・場の状態の一部を並べただけの`list[float]`）を1つ添える**に
+留め、「本格的な特徴量設計は利用者に委ねる」というスタンスは poke-env と揃える。
+
+### 論点3: 対戦相手（opponent）の扱い
+
+RLでは「学習対象1体 vs 固定/ランダムな対戦相手」という単一エージェント構成がまず必要
+（poke-env の `SingleAgentWrapper` に相当）。対戦相手は既存の `Player` サブクラス
+（`RandomPlayer` / `MaxDamagePlayer` / `TreeSearchPlayer` 等）をそのまま使う
+（新規クラスを作らない）。自己対戦（マルチエージェント、PettingZoo相当）は本計画のスコープ外。
+
+## モジュール設計: `src/jpoke/rl.py`
+
+```python
+"""強化学習を始めるための補助機能。
+
+外部ライブラリ（gymnasium 等）には一切依存しない。reset()/step() など
+gymnasium と同じ形のメソッド名を持つが、返り値は list/dict/float/bool のみで
+構成する。gymnasium.Env を実際に使いたい場合は、本モジュールの戻り値を
+そのまま各メソッドの戻り値に使えばよい。
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+from jpoke.core.battle import Battle
+from jpoke.core.player import Player
+from jpoke.enums.command import Command
+
+# 実際の行動として選ばれることのない特殊コマンドは行動空間から除外する
+_EXCLUDED = (Command.STRUGGLE, Command.FORCED)
+ACTION_COMMANDS: tuple[Command, ...] = tuple(c for c in Command if c not in _EXCLUDED)
+ACTION_SPACE_SIZE: int = len(ACTION_COMMANDS)
+
+
+def command_to_action(command: Command) -> int:
+    """Command を RL 用の整数行動（0 〜 ACTION_SPACE_SIZE-1）に変換する。"""
+    return ACTION_COMMANDS.index(command)
+
+
+def action_to_command(action: int) -> Command:
+    """RL 用の整数行動を Command に変換する（逆変換）。"""
+    return ACTION_COMMANDS[action]
+
+
+def get_action_mask(battle: Battle, player: Player) -> list[int]:
+    """現在選択可能なコマンドを1、それ以外を0とする長さ ACTION_SPACE_SIZE のマスクを返す。"""
+    available = set(battle.available_commands(player))
+    return [1 if c in available else 0 for c in ACTION_COMMANDS]
+
+
+@dataclass
+class RewardWeights:
+    """reward_computing_helper 相当の重み設定。既定は poke-env と同じ0（勝敗のみ1.0）。"""
+    fainted: float = 0.0
+    hp: float = 0.0
+    status: float = 0.0
+    victory: float = 1.0
+
+
+def calc_state_value(battle: Battle, player: Player, weights: RewardWeights) -> float:
+    """現在の対戦状態の評価値を計算する（差分報酬の元になる値。poke-envのreward_computing_helperと同じ考え方）。"""
+    opponent = battle.opponent(player)
+    value = 0.0
+    for mon in battle.get_team(player):
+        value += mon.hp_fraction * weights.hp
+        if mon.fainted:
+            value -= weights.fainted
+        elif mon.ailment.name:
+            value -= weights.status
+    for mon in battle.get_team(opponent):
+        value -= mon.hp_fraction * weights.hp
+        if mon.fainted:
+            value += weights.fainted
+        elif mon.ailment.name:
+            value += weights.status
+    if battle.won(player):
+        value += weights.victory
+    elif battle.lost(player):
+        value -= weights.victory
+    return value
+
+
+def embed_battle_basic(battle: Battle, player: Player) -> list[float]:
+    """観測ベクトル化の最小参考実装（HP割合・瀕死・状態異常有無を並べただけ）。
+
+    本格的な特徴量設計（技・タイプ相性・場の状態等）は利用者に委ねる。
+    """
+    ...
+
+
+class RLBattleEnv:
+    """gymnasiumのreset()/step()と同じ形の薄いラッパー。
+
+    学習対象は `learner`（行動をRL側が決める）、対戦相手は `opponent`（既存の
+    Playerサブクラスがそのまま行動を決める）。強制交代（瀕死交代等）は
+    `opponent`/`learner`双方とも既定のchoose_command（先頭コマンド）に
+    フォールバックする（論点1のA案。将来的にB案でRL行動として公開可能にする余地あり）。
+    """
+
+    def __init__(
+        self,
+        learner: Player,
+        opponent: Player,
+        *,
+        reward_weights: RewardWeights | None = None,
+        max_turns: int = 100,
+        **battle_kwargs,
+    ):
+        self.learner = learner
+        self.opponent = opponent
+        self.reward_weights = reward_weights or RewardWeights()
+        self.max_turns = max_turns
+        self._battle_kwargs = battle_kwargs
+        self.battle: Battle | None = None
+
+    def reset(self) -> tuple[list[int], dict]:
+        """新しい対戦を開始し、(action_mask, info) を返す。"""
+        self.battle = Battle(self.learner, self.opponent, **self._battle_kwargs)
+        self.battle.start()
+        return get_action_mask(self.battle, self.learner), {}
+
+    def step(self, action: int) -> tuple[list[int], float, bool, bool, dict]:
+        """1手を実行し、(action_mask, reward, terminated, truncated, info) を返す。"""
+        assert self.battle is not None
+        command = action_to_command(action)
+        # 論点1: switchフェーズの解決は resolve_command 内部で相手/学習対象双方の
+        # 既定choose_commandに委ねられる（学習対象のフェーズがaction以外の場合の扱いは
+        # 実装時に command_manager.validate_command / phase を見て確定させる）
+        opponent_command = self.battle.resolve_command("action", self.opponent)[self.opponent]
+        self.battle.step({self.learner: command, self.opponent: opponent_command})
+        reward = calc_state_value(self.battle, self.learner, self.reward_weights)
+        terminated = self.battle.finished
+        truncated = (not terminated) and self.battle.turn >= self.max_turns
+        return get_action_mask(self.battle, self.learner), reward, terminated, truncated, {}
+```
+
+- `RLBattleEnv.step()` の具体的な配線（`resolve_command`の呼び分け、フェーズが `"switch"` の
+  ときの扱い）は実装時に `core/command_manager.py` / `core/turn_controller.py` を再確認して
+  確定させる（上記コードはあくまで設計方針を示す試案であり、実装ステップで検証する）。
+- `calc_state_value` は「前回呼び出し時との差分」を返す poke-env の `reward_computing_helper`
+  とは違い、**呼び出し時点の絶対評価値**を返す純粋関数にする（状態を持たない）。差分報酬が
+  欲しい利用者は前回値を自分で保持して引き算すればよい（`WeakKeyDictionary`のような内部状態は
+  jpoke側には持たせない、というシンプルさ優先の判断）。
+
+## 実装ステップ
+
+1. `src/jpoke/rl.py` を新規作成し、`ACTION_COMMANDS` / `command_to_action` /
+   `action_to_command` / `get_action_mask` を実装する
+2. `RewardWeights` / `calc_state_value` を実装する
+3. `embed_battle_basic` の最小参考実装を実装する（対象は要検討: 自分の場のポケモンの
+   HP割合・状態異常有無・相手の場のポケモンの同項目、程度に留める）
+4. `RLBattleEnv` を実装する（論点1のA案で、まず「学習対象が瀕死交代を要求されない対戦
+   （相手の技構成やレベル差である程度回避できるテストシナリオ）」で動作確認する）
+5. `examples/` に `04_others/` または新規カテゴリで最小の学習ループ例
+   （Q学習等、外部ライブラリ不要な最小のRLアルゴリズムでよい）を1つ追加する
+   （poke-envのRL exampleがPyTorch前提なのに対し、jpoke側は「外部ライブラリなしでも
+   動く」ことを示す差別化ポイントにする）
+6. `tests/test_rl.py`（新規）でユニットテストを書く:
+   - `command_to_action`/`action_to_command` の往復変換
+   - `get_action_mask` が `available_commands` と一致すること
+   - `calc_state_value` の重み付け計算（poke-envのdocstring例と同じ数値で検証: fainted_value=1,
+     status_value=0.5, hp_value=1 の場合に -1 になるケース等）
+   - `RLBattleEnv.reset()`/`step()` の基本ループが最後まで例外なく完走すること
+     （`tests/test_utils.py` の `start_battle` 等は使わず、素の `Player`/`Battle` で構成する）
+7. `python -m pytest tests/ -v` で既存テストに regression がないことを確認する
+8. `.internal/poke-env/rl_features_analysis.md` に「実装済み」の追記をする
+
+## 対象外（今回のスコープ外）
+
+- `gymnasium`/`pettingzoo` への依存追加、実際の `gymnasium.Env`/`ParallelEnv` サブクラスの提供
+- マルチエージェント・自己対戦環境（PettingZoo相当）
+- 論点1のB案（スレッド+キューによる強制交代のRL行動化）— 将来拡張候補として明記のみ
+- 本格的な特徴量設計（技相性・場の状態全体等を含む `embed_battle` の実用実装）— 最小参考実装に留める
+- 具体的なRLアルゴリズム（DQN/PPO等）の実装 — `RLBattleEnv` は環境のみ提供し、
+  学習アルゴリズムは利用者（または `examples/` の最小サンプル）に委ねる

--- a/.internal/plan/poke-env/rl_support.md
+++ b/.internal/plan/poke-env/rl_support.md
@@ -40,6 +40,10 @@ RLを始めるための一貫したAPIは未整備。
 - `Battle.play_out(max_turns)` / `Player.battle_against(*opponents, n_battles, on_battle_end, **battle_kwargs)`
   （実装済み。一括対戦・戦績集計）
 - `Pokemon.hp_fraction` / `fainted` / `ailment.name`（状態異常の有無判定に使用）
+- `total_hp_ratio(battle, target) -> float`（`players/tree_search_player.py` のモジュール関数）—
+  対象プレイヤーの生存ポケモンのHP割合合計を返す既存関数。`TreeSearchPlayer.evaluate()`
+  （既定の葉ノード評価）が `total_hp_ratio(self) - total_hp_ratio(opponent)` として使っており、
+  下記 `calc_state_value()` のHP項はこれをそのまま再利用する（詳細は論点4）。
 
 ## 設計上の論点（要ユーザー判断 or 実装時に確定させる）
 
@@ -83,6 +87,23 @@ RLでは「学習対象1体 vs 固定/ランダムな対戦相手」という単
 （`RandomPlayer` / `MaxDamagePlayer` / `TreeSearchPlayer` 等）をそのまま使う
 （新規クラスを作らない）。自己対戦（マルチエージェント、PettingZoo相当）は本計画のスコープ外。
 
+### 論点4: `TreeSearchPlayer` の既存評価ロジックとの重複を避ける
+
+`players/tree_search_player.py` には既に「盤面を数値評価する」関数が2つ存在する:
+
+- `total_hp_ratio(battle, target) -> float`（モジュール関数）: 対象プレイヤーの生存ポケモンの
+  HP割合合計
+- `TreeSearchPlayer.evaluate(battle) -> float`（既定の葉ノード評価）: 勝敗確定時は ±inf、
+  それ以外は `total_hp_ratio(self) - total_hp_ratio(opponent)`
+
+これは目的（ミニマックス探索の葉ノード評価。終端を±infで確実に選ばせる必要がある）が
+`calc_state_value()`（RL報酬シェーピング用の有限重み付き差分値。poke-envの
+`reward_computing_helper` 相当）と異なるため、**関数自体は分けて残す**。ただし
+「自チームの残りHP割合合計」という共通部分まで独自に再実装すると、片方だけ挙動を
+調整した際に評価基準が静かに食い違う恐れがある。そのため `calc_state_value()` の
+hp項は `total_hp_ratio()` を import して再利用し、fainted/status 項のみ独自にループする
+（実装は下記モジュール設計を参照）。
+
 ## モジュール設計: `src/jpoke/rl.py`
 
 ```python
@@ -99,6 +120,7 @@ from dataclasses import dataclass
 from jpoke.core.battle import Battle
 from jpoke.core.player import Player
 from jpoke.enums.command import Command
+from jpoke.players.tree_search_player import total_hp_ratio
 
 # 実際の行動として選ばれることのない特殊コマンドは行動空間から除外する
 _EXCLUDED = (Command.STRUGGLE, Command.FORCED)
@@ -132,17 +154,19 @@ class RewardWeights:
 
 
 def calc_state_value(battle: Battle, player: Player, weights: RewardWeights) -> float:
-    """現在の対戦状態の評価値を計算する（差分報酬の元になる値。poke-envのreward_computing_helperと同じ考え方）。"""
+    """現在の対戦状態の評価値を計算する（差分報酬の元になる値。poke-envのreward_computing_helperと同じ考え方）。
+
+    HP項は `TreeSearchPlayer.evaluate()` と同じ `total_hp_ratio()` を再利用する
+    （論点4: 「自チームの残りHP割合合計」を独自に再実装して評価基準が食い違うのを防ぐ）。
+    """
     opponent = battle.opponent(player)
-    value = 0.0
+    value = (total_hp_ratio(battle, player) - total_hp_ratio(battle, opponent)) * weights.hp
     for mon in battle.get_team(player):
-        value += mon.hp_fraction * weights.hp
         if mon.fainted:
             value -= weights.fainted
         elif mon.ailment.name:
             value -= weights.status
     for mon in battle.get_team(opponent):
-        value -= mon.hp_fraction * weights.hp
         if mon.fainted:
             value += weights.fainted
         elif mon.ailment.name:
@@ -220,7 +244,8 @@ class RLBattleEnv:
 
 1. `src/jpoke/rl.py` を新規作成し、`ACTION_COMMANDS` / `command_to_action` /
    `action_to_command` / `get_action_mask` を実装する
-2. `RewardWeights` / `calc_state_value` を実装する
+2. `RewardWeights` / `calc_state_value` を実装する（HP項は `players/tree_search_player.py` の
+   `total_hp_ratio()` を import して再利用し、独自に再実装しない。論点4参照）
 3. `embed_battle_basic` の最小参考実装を実装する（対象は要検討: 自分の場のポケモンの
    HP割合・状態異常有無・相手の場のポケモンの同項目、程度に留める）
 4. `RLBattleEnv` を実装する（論点1のA案で、まず「学習対象が瀕死交代を要求されない対戦

--- a/.internal/poke-env/rl_features_analysis.md
+++ b/.internal/poke-env/rl_features_analysis.md
@@ -110,8 +110,12 @@ poke_env/environment/
    部分観測コピー」を返すのみで、数値テンソル/配列への変換は利用者側に委ねられている
    （poke-envも同様に「利用者が実装する」設計だが、参考実装や助言用のヘルパーは一切ない）。
 3. **報酬シェーピングのヘルパー**（`reward_computing_helper` 相当）— HP割合・瀕死・状態異常・勝敗を
-   使った差分報酬という考え方はjpokeにない。`tod_score(alpha)`（分類D）はダメージレース評価用の
-   スコアで、エピソード単位の報酬シェーピングとは目的が異なる。
+   使った差分報酬というAPIとしての形はjpokeにない。`tod_score(alpha)`（分類D）はダメージレース評価用の
+   スコアで、エピソード単位の報酬シェーピングとは目的が異なる。ただし構成要素の一部は既にある:
+   `total_hp_ratio(battle, target)`（`players/tree_search_player.py`）が「チームの残りHP割合合計」を
+   既に提供しており、`TreeSearchPlayer.evaluate()`（ミニマックス葉ノード評価、勝敗確定時は±inf）が
+   これを使っている。RL用の報酬ヘルパー（`rl_support.md` の `calc_state_value`）はこの関数を
+   再利用し、HP項の計算ロジックを二重実装しない設計にする（詳細は `rl_support.md` 論点4）。
 4. **行動マスク配列としての出力**（`Command`自体は固定順Enumで実質int変換済みだが、
    `get_available_commands(player)` の結果を `Discrete(N)` 用の0/1マスク配列に変換する層は未整備）。
 5. **`gymnasium`/`pettingzoo` への依存自体**（jpokeの実行時依存には一切なし。追加するかどうかも論点）。

--- a/.internal/poke-env/rl_features_analysis.md
+++ b/.internal/poke-env/rl_features_analysis.md
@@ -1,0 +1,190 @@
+# poke-env の強化学習(RL)関連機能 調査書
+
+調査日: 2026-07-21
+
+## 結論（真偽）
+
+**事実。しかも「一機能」ではなく poke-env の主目的そのもの。**
+
+- PyPI/GitHub 双方の `pyproject.toml` で `description = "A python interface for training
+  Reinforcement Learning bots to battle on pokemon showdown."` と明記されている（poke-env 0.15.0）。
+- 実行時依存に `gymnasium>=1.0.0` と `pettingzoo>=1.24.3` を持つ。単なる「Gym風のオプション機能」
+  ではなく、RL用ライブラリ（Farama Gymnasium / PettingZoo）をコア依存として組み込んでいる。
+- 既存の `.internal/poke-env/compat_analysis.md` / `compat_plan.md`（属性・命名レベルの互換調査）は
+  `Battle`/`Pokemon`/`Move`/`Player` の**データモデル**の互換性のみを扱っており、RL用の
+  `PokeEnv`（Gymnasium/PettingZoo環境クラス）自体には触れていなかった。今回はその欠けていた部分の調査。
+
+## poke-env の RL 関連 API
+
+### モジュール構成（現行 `master`、0.15.0 時点で実機確認）
+
+```
+poke_env/environment/
+  env.py               # PokeEnv 基底クラス（PettingZoo ParallelEnv を継承）
+  singles_env.py        # SinglesEnv(PokeEnv[int64])
+  doubles_env.py         # DoublesEnv(PokeEnv[ndarray])
+  single_agent_wrapper.py # SingleAgentWrapper（標準 Gymnasium Env への単一エージェント化）
+```
+
+### `PokeEnv` の実体（重要な点）
+
+- `class PokeEnv(ParallelEnv[str, Dict[str, Any], ActionType])` — **2体の `_EnvPlayer` を裏で
+  Pokémon Showdown サーバーに接続させ**、その対戦を PettingZoo の `step()`/`reset()` API で
+  ラップしたもの。`asyncio` イベントループを別スレッドで回し、`_AsyncQueue` で
+  行動（`BattleOrder`）とバトル状態（`AbstractBattle`）をやり取りする。
+- つまり **「サーバー不要の軽量シミュレータに Gym API を被せたもの」ではない**。内部は
+  ネットワーク越しの実対戦そのものであり、`compat_analysis.md` §0 で整理済みの
+  「実行基盤（要サーバー）」「通信方式（WebSocket）」「同期モデル（asyncio）」という
+  poke-env の制約をそのまま引き継いでいる。
+
+### 実装が必須の抽象メソッド
+
+| メソッド | シグネチャ | 役割 |
+|---|---|---|
+| `calc_reward(battle) -> float` | インスタンスメソッド | 現在のバトル状態から報酬を計算 |
+| `embed_battle(battle) -> Any` | インスタンスメソッド | バトル状態を観測ベクトル（Gymnasium互換形式）に変換 |
+| `action_to_order(action, battle, fake, strict) -> BattleOrder` | staticmethod | 行動値→コマンド変換 |
+| `order_to_action(order, battle, fake, strict) -> ActionType` | staticmethod | コマンド→行動値変換（逆方向） |
+| `get_action_mask(battle) -> list[int]` | staticmethod | 合法行動のマスク配列 |
+| `get_action_space_size(gen) -> int` | staticmethod | 世代別の行動空間サイズ |
+
+### `SinglesEnv` の行動エンコーディング（int64 単一値）
+
+```
+-2: デフォルト行動   -1: 投了
+ 0-5:  交代（最大6体）
+ 6-9:  通常技（最大4）
+10-13: メガシンカ+技
+14-17: Z技+技
+18-21: ダイマックス+技
+22-25: テラスタル+技
+```
+
+`DoublesEnv` は行動が配列（各要素に -2〜2 のターゲット指定を追加）で、`get_action_mask_individual()`
+で個別マスクも取れる。
+
+### `reward_computing_helper()`（報酬シェーピングの標準実装）
+
+`fainted_value` / `hp_value` / `status_value` / `victory_value` の重み付けで、**前回呼び出し時との
+状態値の差分**を報酬として返す（`WeakKeyDictionary` でバトルごとに前回値を保持）。
+`battle.won` / `battle.lost` を使うため、poke-env 側の `won`/`lost` が `bool | None` プロパティで
+あることが前提になっている。
+
+### 観測空間
+
+`observation_spaces` に `Dict({"observation": embed_battleの型, "action_mask": Box(...)})` が
+自動で組み立てられる（`__setattr__` オーバーライドで気づかれにくい形で注入されている）。
+つまり **action masking が一級市民として組み込まれている**。
+
+### シングル/マルチエージェント
+
+- `PokeEnv` 自体は2エージェント同時対戦の `ParallelEnv`（マルチエージェントRL、self-play前提）。
+- `SingleAgentWrapper` で「片方を固定オポーネントにした単一エージェントの標準 `gymnasium.Env`」
+  に変換できる（一般的なRL入門はこちら経由）。
+
+## jpoke の現状（RLの観点で何があり、何がないか）
+
+**既にあるもの**
+
+- `build_observation(observer)`（`compat_analysis.md` 分類D）— 相手の非公開情報を隠した
+  部分観測ビューを明示的に取得できる。poke-env の「部分観測がデフォルト」という前提を、
+  jpoke は「完全情報がデフォルトだが要求すれば部分観測に変換できる」という設計で担保済み。
+- `TreeSearchPlayer` / `MinimaxPlayer`（`players/tree_search_player.py`, `minimax_player.py`）—
+  探索ベースのAI基底実装。ただし学習（重み更新）は行わない静的評価関数ベース。
+- `Command` Enum（型安全な行動表現）、`Battle.get_available_commands(player)`（合法手の列挙）—
+  poke-env の `get_action_mask` に相当する情報は既に存在するが、**int⇔Command の固定エンコーディング
+  としては未整備**（`available_moves`/`available_switches` は `list[Move]`/`list[Pokemon]` を返す
+  互換propertyまでで止まっている。`compat_plan.md` Phase3）。
+- `Player.battle_against()`（`compat_plan.md` Phase5、実装済み）— 同期的な一括対戦・戦績集計。
+  RLの「多数エピソードを回す」用途にそのまま使える下地。
+- `Battle.copy()` / ロールアウト — `examples/05_advanced/04_janken_nash_cfr.py` が
+  `Battle.copy()` を使った自己対戦学習（CFR風のregret matching）を実演済み。**表形式の学習**
+  （tabular RL）の実例は既にある。
+
+**ないもの（poke-envのPokeEnvに相当する部分）**
+
+1. **`gymnasium.Env` 互換のクラス**（`reset()`/`step()`/`action_space`/`observation_space` を
+   Gymnasium仕様で持つラッパー）が存在しない。`Battle.step()` はあるが、これは戦闘ターン進行の
+   意味で、Gym の `step(action) -> (obs, reward, terminated, truncated, info)` とは無関係。
+2. **観測のベクトル化（`embed_battle` 相当）** — `build_observation()` は「jpoke Battleオブジェクトの
+   部分観測コピー」を返すのみで、数値テンソル/配列への変換は利用者側に委ねられている
+   （poke-envも同様に「利用者が実装する」設計だが、参考実装や助言用のヘルパーは一切ない）。
+3. **報酬シェーピングのヘルパー**（`reward_computing_helper` 相当）— HP割合・瀕死・状態異常・勝敗を
+   使った差分報酬という考え方はjpokeにない。`tod_score(alpha)`（分類D）はダメージレース評価用の
+   スコアで、エピソード単位の報酬シェーピングとは目的が異なる。
+4. **行動マスク配列としての出力**（`Command`自体は固定順Enumで実質int変換済みだが、
+   `get_available_commands(player)` の結果を `Discrete(N)` 用の0/1マスク配列に変換する層は未整備）。
+5. **`gymnasium`/`pettingzoo` への依存自体**（jpokeの実行時依存には一切なし。追加するかどうかも論点）。
+
+## アーキテクチャ上の非対称性（見落としやすい点）
+
+poke-env の `PokeEnv` は「RL向けの機能」を持っているが、その実体は**実サーバー対戦をGym APIで
+ラップしただけ**であり、俊敏性・並列実行性能の面ではむしろ弱い（1ステップごとにネットワークI/O・
+asyncioスレッド切り替えが発生する）。
+
+一方 jpoke は既に「サーバー不要・同期・プロセス内関数呼び出しのみ」という、RL学習（大量ロールアウト
+が必要）にとって本質的に有利な特性を持っている（README「計算速度」章: 1step 3.8ms、
+`ProcessPoolExecutor` 並列化の実例も `examples/05_advanced/03_janken_nash_fictitious_play.py` に有）。
+つまり **jpokeがGym互換ラッパーを提供すれば、poke-envより高速なRL環境になり得る** というのが
+今回調査で見えた最大の機会。逆に言うと、RL対応の欠如は「本質的な設計の違いによる原理的な制約」では
+なく「単に未実装」であるため、対応する価値がある可能性が高い。
+
+## 検討: jpoke に必要な対応（選択肢）
+
+### A案: 対応しない（現状維持）
+- 理由: README「対象範囲」はチャンピオンズシングル対戦のシミュレーション・ダメージ計算が主眼で、
+  RLフレームワーク自体の提供は明言されていない。`TreeSearchPlayer`/`MinimaxPlayer` や
+  `janken_nash_cfr.py` の自己対戦学習実例で「AI開発」需要は既にある程度満たしている、という立場もありうる。
+- リスク: poke-env ユーザーが「RL目的でjpokeに来たが最小限のGym Envもない」と離脱する可能性。
+  `compat_plan.md`/`compat_analysis.md` を整備してpoke-env経験者の導線を作ってきた既存投資と矛盾する。
+
+### B案: 軽量 Gymnasium 互換ラッパーを新設（推奨候補）
+- `src/jpoke/gym_env.py`（または `interop/gym_env.py`）に、**単一プロセス・同期の**
+  `gymnasium.Env` サブクラスを追加する。poke-envのような2エージェント`ParallelEnv`ではなく、
+  まずは `SingleAgentWrapper` 相当（片方を固定オポーネントにした単一エージェント環境）から始めるのが
+  費用対効果が高い。
+- 最小構成案:
+  - `action_space`: `Discrete(N)`（`Command` の列挙順に対応）。**`enums/command.py` を確認したところ、
+    `Command` はすでに `SWITCH_0..9` / `MOVE_0..9` / `TERASTAL_0..9` / `MEGAEVOL_0..9` /
+    `GIGAMAX_0..9` / `ZMOVE_0..9`（+特殊コマンド `STRUGGLE`/`FORCED`）という固定順の Enum で、
+    `index` プロパティ・`get_*_command(index)` classmethod まで揃っている。poke-envの
+    `action_to_order`/`order_to_action` に相当する「int⇔行動」変換の**土台はほぼ完成済み**で、
+    新設が要るのは「合法手だけをmask/列挙する層」と「Gym Envとして`Discrete(N)`に詰め直す層」に
+    限られる（ゼロから設計する必要はない）**
+  - `observation_space`: 利用者が `embed_battle` 相当を実装する前提は poke-env と揃えるが、
+    `build_observation()` から素朴な数値ベクトルを組み立てる**参考実装**を1つ添える
+    （poke-envにもこの参考実装がなく独自色を出せる）
+  - `reward` : `reward_computing_helper` 相当のヘルパー関数を用意（HP割合・瀕死・状態異常・勝敗の
+    重み付け差分。既存の `Battle.won`/`lost`（`compat_plan.md` Phase3、`Player`引数版）と整合させる）
+  - `step`/`reset` : 既存の `Battle.step()` / `Player.battle_against()` の下地をそのまま流用できる
+    （サーバー・asyncio不要な分、poke-envの `_EnvPlayer`/`_AsyncQueue` に相当する複雑さが丸ごと不要）
+- 依存関係: `gymnasium` を実行時必須依存に追加するかはトレードオフ。`[project.optional-dependencies]`
+  （例: `pip install jpoke[gym]`）に切り出せば、通常利用者への影響をゼロにできる。
+- CLAUDE.md「対象はポケモンチャンピオンズのシングルバトルのみ」との整合: ダブルバトル相当の
+  `DoublesEnv` は最初から対象外でよい（poke-envとは違い、jpoke自体がダブル非対応のため自然に一致）。
+
+### C案: 既存の `interop/poke_env.py` 計画（Battleコンバータ、未着手）にRL変換を統合
+- `.internal/plan/poke-env/poke_env_battle_converter.md` は「poke-env の進行中Battleをjpoke Battleに
+  変換する」計画だが、これはRLとは別軸（既存のShowdown対戦ログをjpokeで解析したい場合の用途）。
+- RL用途で欲しいのは逆方向、すなわち「jpoke Battleから学習用の行動/観測/報酬を作る」変換であり、
+  C案（poke-env→jpoke一方向）の対象範囲には元々含まれない。B案と混同しないよう切り分けが必要。
+
+## 推奨
+
+B案（軽量 Gymnasium 互換ラッパーの新設）を推奨。理由:
+
+1. poke-env のRL機能は「サーバー接続込みのGym化」であり、jpokeが持つ「サーバー不要・高速・
+   完全情報」という強みと組み合わせると、素直に上位互換のRL環境になり得る。
+2. 既存の `.internal/poke-env/compat_*.md` 一連の投資（poke-env経験者の導線づくり）の延長として
+   自然。「poke-envのGymnasiumインターフェースを知っている人が次に触るもの」を用意する形になる。
+3. `players/` フレームワーク（`TreeSearchPlayer` 等）と共存可能（`Player`のサブクラスとしてではなく
+   別レイヤーの`gymnasium.Env`として追加するため、既存の設計を壊さない）。
+
+ただし実装着手前に、以下はユーザー判断が必要:
+
+- `gymnasium` を optional dependency として追加する方針でよいか
+- 行動空間の対象範囲（テラスタル・メガシンカを含めるか。Champions実際のルールでの対応状況を
+  `enums/command.py`・`.internal/spec/` で要確認）
+- 観測ベクトル化の参考実装をどこまで作り込むか（最小限の例に留めるか、実用的な特徴量セットまで
+  用意するか）
+- マルチエージェント（自己対戦、PettingZoo相当）まで見据えるか、まずは単一エージェントのみか

--- a/.internal/poke-env/rl_features_analysis.md
+++ b/.internal/poke-env/rl_features_analysis.md
@@ -138,30 +138,39 @@ asyncioスレッド切り替えが発生する）。
 - リスク: poke-env ユーザーが「RL目的でjpokeに来たが最小限のGym Envもない」と離脱する可能性。
   `compat_plan.md`/`compat_analysis.md` を整備してpoke-env経験者の導線を作ってきた既存投資と矛盾する。
 
-### B案: 軽量 Gymnasium 互換ラッパーを新設（推奨候補）
-- `src/jpoke/gym_env.py`（または `interop/gym_env.py`）に、**単一プロセス・同期の**
-  `gymnasium.Env` サブクラスを追加する。poke-envのような2エージェント`ParallelEnv`ではなく、
-  まずは `SingleAgentWrapper` 相当（片方を固定オポーネントにした単一エージェント環境）から始めるのが
-  費用対効果が高い。
+### B案: 外部ライブラリ非依存のRL支援ヘルパーを新設（推奨候補・ユーザー方針: 外部ライブラリは追加しない）
+
+**ユーザー方針（2026-07-21確認）: `gymnasium`/`pettingzoo` 等の外部ライブラリは依存に追加しない。
+その代わり、強化学習を始めるのに便利な機能（行動の列挙・マスク・観測ベクトル化・報酬ヘルパー）は
+jpoke自身が素の Python（`dependencies = []` を維持）で提供する。**
+
+- `gymnasium.Env` を継承するクラスは作らない。代わりに `reset()`/`step(action)` という
+  gymnasium と同じ「形」のメソッドを持つが、返り値は `gymnasium.spaces.*` オブジェクトではなく
+  素の `list[int]`/`dict`/`float`/`bool` のみで構成する薄いクラス（例: `RLBattleEnv`）を用意する。
+  利用者が実際に `gymnasium.Env` を使いたい場合は、数行のアダプタ（`observation, reward,
+  terminated, truncated, info = rl_env.step(action)` をそのまま右辺に流すだけ）で被せられる
+  設計にする（＝gymnasium前提の学習コードとの互換性は保ちつつ、jpoke自体はimportしない）。
 - 最小構成案:
-  - `action_space`: `Discrete(N)`（`Command` の列挙順に対応）。**`enums/command.py` を確認したところ、
-    `Command` はすでに `SWITCH_0..9` / `MOVE_0..9` / `TERASTAL_0..9` / `MEGAEVOL_0..9` /
-    `GIGAMAX_0..9` / `ZMOVE_0..9`（+特殊コマンド `STRUGGLE`/`FORCED`）という固定順の Enum で、
-    `index` プロパティ・`get_*_command(index)` classmethod まで揃っている。poke-envの
-    `action_to_order`/`order_to_action` に相当する「int⇔行動」変換の**土台はほぼ完成済み**で、
-    新設が要るのは「合法手だけをmask/列挙する層」と「Gym Envとして`Discrete(N)`に詰め直す層」に
-    限られる（ゼロから設計する必要はない）**
-  - `observation_space`: 利用者が `embed_battle` 相当を実装する前提は poke-env と揃えるが、
-    `build_observation()` から素朴な数値ベクトルを組み立てる**参考実装**を1つ添える
-    （poke-envにもこの参考実装がなく独自色を出せる）
-  - `reward` : `reward_computing_helper` 相当のヘルパー関数を用意（HP割合・瀕死・状態異常・勝敗の
-    重み付け差分。既存の `Battle.won`/`lost`（`compat_plan.md` Phase3、`Player`引数版）と整合させる）
-  - `step`/`reset` : 既存の `Battle.step()` / `Player.battle_against()` の下地をそのまま流用できる
-    （サーバー・asyncio不要な分、poke-envの `_EnvPlayer`/`_AsyncQueue` に相当する複雑さが丸ごと不要）
-- 依存関係: `gymnasium` を実行時必須依存に追加するかはトレードオフ。`[project.optional-dependencies]`
-  （例: `pip install jpoke[gym]`）に切り出せば、通常利用者への影響をゼロにできる。
+  - **行動の列挙・マスク**: `enums/command.py` の `Command` はすでに `SWITCH_0..9` / `MOVE_0..9` /
+    `TERASTAL_0..9` / `MEGAEVOL_0..9` / `GIGAMAX_0..9` / `ZMOVE_0..9` という固定順のEnumで、
+    `index` プロパティ・`get_*_command(index)` classmethodまで揃っている。これに「固定サイズの
+    行動空間（`Command`一覧に対応する整数レンジ）」「`get_available_commands(player)` から
+    0/1マスク配列（`list[int]`、gymnasiumの`Box`は使わずただのlist）を作る関数」を追加すれば
+    ほぼ完成する（ゼロから設計する必要はない）
+  - **観測ベクトル化**: `build_observation()` から素朴な数値配列（`list[float]`）を組み立てる
+    参考実装を1つ用意する（poke-envの`embed_battle`は利用者に委ねる設計で参考実装自体がないため、
+    ここはjpoke独自の付加価値になる）
+  - **報酬ヘルパー**: `reward_computing_helper` 相当の**純粋関数**（クラスメソッドではなく、
+    `Battle`と前回の状態値を受け取り差分を返す関数）を用意する。HP割合・瀕死・状態異常・勝敗の
+    重み付けは poke-env と同じ発想を踏襲しつつ、`Battle.won(player)`/`lost(player)`（`Player`引数版、
+    実装済み）を使う
+  - `step`/`reset`: 既存の `Battle.step()` / `Battle.play_out()` / `Player.battle_against()` の下地を
+    そのまま流用できる（サーバー・asyncio・スレッドが一切不要な分、poke-envの
+    `_EnvPlayer`/`_AsyncQueue`相当の複雑さが丸ごと要らない）
+- 依存関係: **追加しない**（`pyproject.toml` の `dependencies = []` を維持）。これにより
+  `pip install jpoke` だけで動く既存の使い勝手を損なわない。
 - CLAUDE.md「対象はポケモンチャンピオンズのシングルバトルのみ」との整合: ダブルバトル相当の
-  `DoublesEnv` は最初から対象外でよい（poke-envとは違い、jpoke自体がダブル非対応のため自然に一致）。
+  対応は最初から対象外でよい（jpoke自体がダブル非対応のため自然に一致）。
 
 ### C案: 既存の `interop/poke_env.py` 計画（Battleコンバータ、未着手）にRL変換を統合
 - `.internal/plan/poke-env/poke_env_battle_converter.md` は「poke-env の進行中Battleをjpoke Battleに
@@ -171,20 +180,18 @@ asyncioスレッド切り替えが発生する）。
 
 ## 推奨
 
-B案（軽量 Gymnasium 互換ラッパーの新設）を推奨。理由:
+B案（外部ライブラリ非依存のRL支援ヘルパー新設）を推奨。理由:
 
 1. poke-env のRL機能は「サーバー接続込みのGym化」であり、jpokeが持つ「サーバー不要・高速・
-   完全情報」という強みと組み合わせると、素直に上位互換のRL環境になり得る。
-2. 既存の `.internal/poke-env/compat_*.md` 一連の投資（poke-env経験者の導線づくり）の延長として
-   自然。「poke-envのGymnasiumインターフェースを知っている人が次に触るもの」を用意する形になる。
-3. `players/` フレームワーク（`TreeSearchPlayer` 等）と共存可能（`Player`のサブクラスとしてではなく
-   別レイヤーの`gymnasium.Env`として追加するため、既存の設計を壊さない）。
+   完全情報」という強みと組み合わせると、素直に上位互換のRL環境になり得る。外部ライブラリの
+   `gymnasium`/`pettingzoo`自体を持ち込まなくても、その「形」だけ真似た薄いクラス・関数群で
+   十分に効果を再現できる。
+2. `dependencies = []` を維持したまま提供できるため、`pip install jpoke` だけで動く既存の
+   使い勝手を一切損なわない（`gymnasium`が使いたい利用者は自分の環境にだけ追加すればよい）。
+3. 既存の `.internal/poke-env/compat_*.md` 一連の投資（poke-env経験者の導線づくり）の延長として
+   自然。「poke-envのGymnasiumインターフェースを知っている人が次に触っても迷わないもの」を
+   用意する形になる。
+4. `players/` フレームワーク（`TreeSearchPlayer` 等）と共存可能（`Player`のサブクラスとしてではなく
+   別レイヤーのヘルパー群として追加するため、既存の設計を壊さない）。
 
-ただし実装着手前に、以下はユーザー判断が必要:
-
-- `gymnasium` を optional dependency として追加する方針でよいか
-- 行動空間の対象範囲（テラスタル・メガシンカを含めるか。Champions実際のルールでの対応状況を
-  `enums/command.py`・`.internal/spec/` で要確認）
-- 観測ベクトル化の参考実装をどこまで作り込むか（最小限の例に留めるか、実用的な特徴量セットまで
-  用意するか）
-- マルチエージェント（自己対戦、PettingZoo相当）まで見据えるか、まずは単一エージェントのみか
+実装計画は `.internal/plan/poke-env/rl_support.md` を参照。


### PR DESCRIPTION
## Summary
- poke-env が強化学習(RL)用インターフェース（Gymnasium/PettingZoo準拠の `PokeEnv`）を主目的として持つことを実機ソース調査で確認し、jpokeとのギャップを整理（`.internal/poke-env/rl_features_analysis.md`）
- 外部ライブラリ（gymnasium/pettingzoo）を依存に追加しない方針のもと、素のPythonで行動列挙・合法手マスク・観測ベクトル化参考実装・報酬シェーピングヘルパー・単一エージェント学習ループ(`RLBattleEnv`)を提供する実装計画を作成（`.internal/plan/poke-env/rl_support.md`）
- 計画中の報酬ヘルパー(`calc_state_value`)が既存の `players/tree_search_player.py` の `total_hp_ratio()` と重複しないよう、HP項を再利用する設計に修正済み

## Test plan
- ドキュメントのみの変更のため、テスト実行は不要
- 次のステップ（実装フェーズ）で `python -m pytest tests/ -v` を実施予定

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>