### PR TITLE
feat(players): CLI上で対話的にコマンド入力できるCLIPlayerを追加

### DIFF
--- a/scripts/cli_battle.py
+++ b/scripts/cli_battle.py
@@ -1,0 +1,43 @@
+"""CLIPlayer でAI相手に対話的に対戦するスクリプト。
+
+`python scripts/cli_battle.py` で実行し、選出・行動コマンドの入力を
+標準入力から求められる。相手は `MaxDamagePlayer`（最大ダメージ技を選ぶ
+だけの単純なAI）。
+"""
+from __future__ import annotations
+
+from jpoke import Battle
+from jpoke.players import CLIPlayer, MaxDamagePlayer
+
+
+def build_teams() -> tuple[CLIPlayer, MaxDamagePlayer]:
+    """デモ用の3vs3チームを構築する。"""
+    human = CLIPlayer("あなた")
+    human.add_pokemon("ピカチュウ", moves=["でんこうせっか", "かみなり", "でんじは"])
+    human.add_pokemon("フシギダネ", moves=["たいあたり", "やどりぎのタネ"])
+    human.add_pokemon("ゼニガメ", moves=["みずでっぽう", "からにこもる"])
+
+    ai = MaxDamagePlayer("AI")
+    ai.add_pokemon("ヒトカゲ", moves=["ひのこ", "ひっかく"])
+    ai.add_pokemon("コラッタ", moves=["たいあたり", "でんこうせっか"])
+    ai.add_pokemon("ポッポ", moves=["つつく", "かぜおこし"])
+
+    return human, ai
+
+
+def main() -> None:
+    human, ai = build_teams()
+    battle = Battle(human, ai, n_selected=2, seed=1)
+    battle.play_out(max_turns=100)
+
+    print("=" * 50)
+    if battle.winner is None:
+        print("結果: 引き分け（ターン上限）")
+    else:
+        print(f"結果: {battle.winner.username} の勝利！")
+    print("=" * 50)
+    battle.print_logs("all")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jpoke/players/__init__.py
+++ b/src/jpoke/players/__init__.py
@@ -2,12 +2,14 @@
 
 木探索フレームワークの `TreeSearchPlayer`（抽象基底）とミニマックス実装の
 `MinimaxPlayer`、ランダム選択の `RandomPlayer`、最大ダメージ技を選ぶ
-`MaxDamagePlayer` など、bot・探索コードから再利用される方策実装をここに置く。
+`MaxDamagePlayer`、標準入出力で対話的に操作する `CLIPlayer` など、
+bot・探索コード・手動対戦から再利用される方策実装をここに置く。
 リプレイ再生用の `ReplayPlayer` / `replay_battle()` は `jpoke.core.replay` を参照。
 """
 from .tree_search_player import TreeSearchPlayer
 from .minimax_player import MinimaxPlayer
 from .random_player import RandomPlayer
 from .max_damage_player import MaxDamagePlayer
+from .cli_player import CLIPlayer
 
-__all__ = ["TreeSearchPlayer", "MinimaxPlayer", "RandomPlayer", "MaxDamagePlayer"]
+__all__ = ["TreeSearchPlayer", "MinimaxPlayer", "RandomPlayer", "MaxDamagePlayer", "CLIPlayer"]

--- a/src/jpoke/players/cli_player.py
+++ b/src/jpoke/players/cli_player.py
@@ -1,0 +1,129 @@
+"""標準入出力でコマンドを入力しながら対戦できるプレイヤー。
+
+`Player.choose_command()` / `choose_selection()` はBattle側から常に同期的に
+呼び出されるため、`input()` でブロッキングするだけで対話操作が成立する
+（非同期対応やイベントループは不要）。
+"""
+from __future__ import annotations
+
+from jpoke import Battle, Player
+from jpoke.enums import Command
+from jpoke.model import Pokemon
+
+
+class CLIPlayer(Player):
+    """標準入出力（input()/print()）でコマンドを入力しながら対戦する人間プレイヤー。
+
+    `choose_selection()` / `choose_command()` の呼び出しごとに現在の盤面
+    （直前ターンのログ、自分・相手の場のポケモンのHP・状態異常・ランク補正・
+    テラスタル状況、天候・フィールド・場の状態）を表示し、番号入力で
+    コマンドを選ばせる。選択肢が1つしかない場合（わるあがき、交代先が
+    1体のみ等）は表示のうえ入力を求めず自動的に確定する。
+    """
+
+    def choose_selection(self, battle: Battle) -> list[int]:
+        """チームを表示し、選出するポケモンの番号を対話的に選ばせる。"""
+        n = battle.n_selected
+        print(f"\n=== {self.username}: 選出（{n}体選んでください） ===")
+        for i, mon in enumerate(self.team):
+            types = "/".join(t for t in mon.types if t)
+            print(f"{i}: {mon.name} (タイプ:{types} 特性:{mon.ability.name} "
+                  f"持ち物:{mon.item.name or 'なし'})")
+            for move in mon.moves:
+                print(f"      - {move.name} (タイプ:{move.type} 分類:{move.category} PP:{move.pp})")
+
+        while True:
+            raw = input(f"選出番号を空白区切りで{n}個入力: ").strip()
+            try:
+                indexes = [int(x) for x in raw.split()]
+            except ValueError:
+                print("数字を空白区切りで入力してください。")
+                continue
+            if len(indexes) != n or len(set(indexes)) != n:
+                print(f"重複なしで{n}個の番号を入力してください。")
+                continue
+            if any(i < 0 or i >= len(self.team) for i in indexes):
+                print(f"0〜{len(self.team) - 1}の範囲で入力してください。")
+                continue
+            return indexes
+
+    def choose_command(self, battle: Battle) -> Command:
+        """現在の盤面を表示し、行動コマンドを対話的に選ばせる。"""
+        self._print_state(battle)
+
+        commands = battle.available_commands(self)
+        if len(commands) == 1:
+            command = commands[0]
+            print(f"選択肢が1つのため自動選択します: {self._describe_command(battle, command)}")
+            return command
+
+        print("--- 選択可能なコマンド ---")
+        for i, command in enumerate(commands):
+            print(f"{i}: {self._describe_command(battle, command)}")
+
+        while True:
+            raw = input("コマンド番号を入力: ").strip()
+            try:
+                choice = int(raw)
+            except ValueError:
+                print("数字を入力してください。")
+                continue
+            if choice < 0 or choice >= len(commands):
+                print(f"0〜{len(commands) - 1}の範囲で入力してください。")
+                continue
+            return commands[choice]
+
+    def _print_state(self, battle: Battle) -> None:
+        """直前までのログと盤面（HP・状態・場の状態）を表示する。"""
+        print(f"\n=== ターン{battle.turn} : {self.username} ===")
+        battle.print_logs()
+
+        opponent = battle.opponent(self)
+        print(f"[自分] {self._describe_mon(battle.get_active(self))}")
+        print(f"[相手] {self._describe_mon(battle.get_active(opponent))}")
+
+        weather, terrain = battle.weather, battle.terrain
+        if weather.is_active:
+            print(f"天候: {weather.name}")
+        if terrain.is_active:
+            print(f"フィールド: {terrain.name}")
+
+        for label, side_player in ((self.username, self), (opponent.username, opponent)):
+            active_fields = [f.name for f in battle.get_side(side_player).fields.values() if f.is_active]
+            if active_fields:
+                print(f"{label}側の場の状態: {', '.join(active_fields)}")
+
+    def _describe_mon(self, mon: Pokemon | None) -> str:
+        """ポケモン1体のHP・状態異常・ランク補正・テラスタル状況を1行で表す。"""
+        if mon is None:
+            return "(場に出ていない)"
+
+        hp = f"HP {mon.hp}/{mon.max_hp}"
+        ailment = f" 状態異常:{mon.ailment.name}" if mon.ailment.is_active else ""
+        boosts = ", ".join(f"{stat}{v:+d}" for stat, v in mon.boosts.items() if v != 0)
+        boost_str = f" ランク:[{boosts}]" if boosts else ""
+        tera = f" (テラス:{mon.tera_type})" if mon.is_terastallized else ""
+        return f"{mon.name}{tera} {hp}{ailment}{boost_str}"
+
+    def _describe_command(self, battle: Battle, command: Command) -> str:
+        """コマンド1件を人間可読な説明文にする。"""
+        if command in (Command.STRUGGLE, Command.FORCED):
+            return "わるあがき" if command == Command.STRUGGLE else "強制続行"
+
+        if command.is_switch:
+            mon = battle.get_team(self)[command.index]
+            return f"交代 → {mon.name} (HP {mon.hp}/{mon.max_hp})"
+
+        move = battle.command_to_move(self, command)
+        prefix = ""
+        if command.is_terastal:
+            prefix = "テラスタル+"
+        elif command.is_megaevol:
+            prefix = "メガシンカ+"
+        elif command.is_gigamax:
+            prefix = "ダイマックス+"
+        elif command.is_zmove:
+            prefix = "Z+"
+        power = move.base_power if move.base_power is not None else "-"
+        return (f"{prefix}{move.name} (タイプ:{move.type} 分類:{move.category} "
+                f"威力:{power} PP:{move.pp}/{move.data.pp})")

--- a/tests/test_cli_player.py
+++ b/tests/test_cli_player.py
@@ -1,0 +1,141 @@
+"""jpoke.players.CLIPlayer の単体テスト。"""
+from jpoke import Battle, Pokemon, Player
+from jpoke.enums import Command
+from jpoke.players import CLIPlayer
+
+def _make_team() -> list[Pokemon]:
+    return [
+        Pokemon("ピカチュウ", item_name="", move_names=["でんこうせっか", "かみなり"]),
+        Pokemon("フシギダネ", item_name="", move_names=["たいあたり"]),
+    ]
+
+def _make_opponent_team() -> list[Pokemon]:
+    # n_selected=2 のテストでも選出できるよう2体用意する
+    return [
+        Pokemon("ゼニガメ", item_name="", move_names=["たいあたり"]),
+        Pokemon("ヒトカゲ", item_name="", move_names=["たいあたり"]),
+    ]
+
+def _scripted_input(monkeypatch, *responses):
+    """`builtins.input` を差し替え、決められた順で応答を返すようにする。
+
+    responsesを使い切った後にさらに `input()` が呼ばれた場合はAssertionErrorに
+    する（＝想定外の追加入力要求がないことを検証できる）。
+    """
+    it = iter(responses)
+
+    def _input(prompt=""):
+        try:
+            return next(it)
+        except StopIteration:
+            raise AssertionError("想定以上にinput()が呼ばれました") from None
+
+    monkeypatch.setattr("builtins.input", _input)
+
+
+def test__describe_commandが交代コマンドの内容を整形する(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = _make_team()
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=2, seed=1)
+    _scripted_input(monkeypatch, "0 1")
+    battle.start()
+
+    with battle.phase_context("action"):
+        text = player1._describe_command(battle, Command.SWITCH_1)
+
+    assert "フシギダネ" in text
+
+
+def test__describe_commandが技コマンドの内容を整形する(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = [Pokemon("ピカチュウ", item_name="", move_names=["かみなり"])]
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=1, seed=1)
+    _scripted_input(monkeypatch, "0")
+    battle.start()
+
+    with battle.phase_context("action"):
+        text = player1._describe_command(battle, Command.MOVE_0)
+
+    assert "かみなり" in text
+    assert "PP" in text
+
+
+def test_choose_commandが不正な入力を再入力させる(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = [Pokemon("ピカチュウ", item_name="", move_names=["でんこうせっか", "かみなり"])]
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=1, seed=1)
+    _scripted_input(monkeypatch, "0", "abc", "99", "0")
+    battle.start()
+
+    with battle.phase_context("action"):
+        assert player1.choose_command(battle) == Command.MOVE_0
+
+
+def test_choose_commandが番号入力でコマンドを選ぶ(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = [Pokemon("ピカチュウ", item_name="", move_names=["でんこうせっか", "かみなり"])]
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=1, seed=1)
+    _scripted_input(monkeypatch, "0", "1")
+    battle.start()
+
+    with battle.phase_context("action"):
+        # 選択可能なコマンドは [MOVE_0, MOVE_1, TERASTAL_0, TERASTAL_1] の順のため、
+        # 番号"1"はかみなり(MOVE_1)を指す
+        assert player1.choose_command(battle) == Command.MOVE_1
+
+
+def test_choose_commandが選択肢1つのとき入力を求めず自動選択する(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = [Pokemon("ピカチュウ", item_name="", move_names=["たいあたり"])]
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=1, seed=1)
+    # choose_selection用の応答のみ用意し、choose_command側では input() が
+    # 呼ばれないこと（=自動選択されること）を _scripted_input の枯渇チェックで確認する
+    _scripted_input(monkeypatch, "0")
+    battle.start()
+
+    # 唯一の技のPPを0にすることで、テラスタル等の分岐を持たない
+    # わるあがき1択の状態を作る（交代先も居ないため選択肢は1つだけになる）
+    battle.get_active(player1).moves[0].pp = 0
+
+    with battle.phase_context("action"):
+        assert player1.choose_command(battle) == Command.STRUGGLE
+
+
+def test_choose_selectionが不正な入力を再入力させる(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = _make_team()
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=2, seed=1)
+    # 数字でない、重複、範囲外の順に無効な入力を経て最後に有効な入力を返す
+    _scripted_input(monkeypatch, "abc", "0 0", "5 0", "0 1")
+
+    assert player1.choose_selection(battle) == [0, 1]
+
+
+def test_choose_selectionが有効な入力をパースする(monkeypatch):
+    player1 = CLIPlayer(username="CLIPlayer")
+    player1.team = _make_team()
+    player2 = Player(username="Player 2")
+    player2.team = _make_opponent_team()
+
+    battle = Battle(player1, player2, n_selected=2, seed=1)
+    _scripted_input(monkeypatch, "1 0")
+
+    assert player1.choose_selection(battle) == [1, 0]


### PR DESCRIPTION
## Summary
- `CLIPlayer(Player)` を追加。`choose_selection()`/`choose_command()` を標準入出力（input()/print()）で対話的に実装し、CLI上でコマンドを入力しながらAI相手に対戦できるようにする
- 毎ターン、直前ターンのログ・自分と相手の場のポケモンのHP/状態異常/ランク補正/テラス状況・天候/フィールド/場の状態を表示してから選択肢を提示する
- 選択肢が1つしかない場合（わるあがき等）は入力を求めず自動選択する
- `scripts/cli_battle.py`: MaxDamagePlayer相手に実際にCLIで対戦できるデモスクリプト

## Test plan
- [x] `tests/test_cli_player.py` 追加（7件、`monkeypatch`でinput()をモックし正常系・不正入力の再入力・選択肢1つ時の自動選択を検証）
- [x] `python -m pytest tests/ -v` 全件パス（6134 passed, 1 skipped）
- [x] 標準入力を疑似応答で埋めて `scripts/cli_battle.py` を3vs3フルバトルで実行し、選出→技選択→交代→勝敗判定まで動作確認済み