### PR TITLE
計画修正: rl.pyの評価ロジックをtree_search_playerから独立させる

### DIFF
--- a/.internal/plan/poke-env/rl_support.md
+++ b/.internal/plan/poke-env/rl_support.md
@@ -40,10 +40,6 @@ RLを始めるための一貫したAPIは未整備。
 - `Battle.play_out(max_turns)` / `Player.battle_against(*opponents, n_battles, on_battle_end, **battle_kwargs)`
   （実装済み。一括対戦・戦績集計）
 - `Pokemon.hp_fraction` / `fainted` / `ailment.name`（状態異常の有無判定に使用）
-- `total_hp_ratio(battle, target) -> float`（`players/tree_search_player.py` のモジュール関数）—
-  対象プレイヤーの生存ポケモンのHP割合合計を返す既存関数。`TreeSearchPlayer.evaluate()`
-  （既定の葉ノード評価）が `total_hp_ratio(self) - total_hp_ratio(opponent)` として使っており、
-  下記 `calc_state_value()` のHP項はこれをそのまま再利用する（詳細は論点4）。
 
 ## 設計上の論点（要ユーザー判断 or 実装時に確定させる）
 
@@ -87,22 +83,27 @@ RLでは「学習対象1体 vs 固定/ランダムな対戦相手」という単
 （`RandomPlayer` / `MaxDamagePlayer` / `TreeSearchPlayer` 等）をそのまま使う
 （新規クラスを作らない）。自己対戦（マルチエージェント、PettingZoo相当）は本計画のスコープ外。
 
-### 論点4: `TreeSearchPlayer` の既存評価ロジックとの重複を避ける
+### 論点4: `TreeSearchPlayer` の既存評価ロジックとは意図的に独立させる
 
-`players/tree_search_player.py` には既に「盤面を数値評価する」関数が2つ存在する:
+`players/tree_search_player.py` には既に「盤面を数値評価する」関数が2つ存在する
+（`total_hp_ratio(battle, target)` と、それを使う `TreeSearchPlayer.evaluate()`）。
+HP割合の合計という計算自体は `calc_state_value()` のHP項と重なって見えるが、
+**`rl.py` からは import しない**。理由:
 
-- `total_hp_ratio(battle, target) -> float`（モジュール関数）: 対象プレイヤーの生存ポケモンの
-  HP割合合計
-- `TreeSearchPlayer.evaluate(battle) -> float`（既定の葉ノード評価）: 勝敗確定時は ±inf、
-  それ以外は `total_hp_ratio(self) - total_hp_ratio(opponent)`
+- `calc_state_value()` は poke-envの `reward_computing_helper` と同じ位置づけで、
+  そもそも利用者が `RewardWeights` で重みを自由に変える／将来的に評価関数ごと
+  差し替えることが前提の「叩き台」。厳密な再利用より、`rl.py` 単体で完結して
+  読める・書き換えやすいことの方が重要
+- `rl.py` は「既存APIの上に乗る薄いレイヤー」（本ファイル冒頭のdocstring方針）として
+  独立性を保ちたい。`players/tree_search_player.py`（ミニマックス探索の実装）に
+  import 依存すると、RL目的で `rl.py` だけ使いたい利用者が探索プレイヤーの
+  モジュールまで引きずり込まれる
+- HP割合合計は `mon.hp / mon.max_hp` の総和という1行程度のロジックで、共有するほどの
+  複雑さがない。将来どちらかの仕様（例: 交代済み欠番の扱い）が変わっても、
+  互いを気にせず独立に調整できる方が安全
 
-これは目的（ミニマックス探索の葉ノード評価。終端を±infで確実に選ばせる必要がある）が
-`calc_state_value()`（RL報酬シェーピング用の有限重み付き差分値。poke-envの
-`reward_computing_helper` 相当）と異なるため、**関数自体は分けて残す**。ただし
-「自チームの残りHP割合合計」という共通部分まで独自に再実装すると、片方だけ挙動を
-調整した際に評価基準が静かに食い違う恐れがある。そのため `calc_state_value()` の
-hp項は `total_hp_ratio()` を import して再利用し、fainted/status 項のみ独自にループする
-（実装は下記モジュール設計を参照）。
+そのため `calc_state_value()` は `total_hp_ratio()` を import せず、HP項も
+fainted/status 項と同様にその場で計算する（実装は下記モジュール設計を参照）。
 
 ## モジュール設計: `src/jpoke/rl.py`
 
@@ -120,7 +121,6 @@ from dataclasses import dataclass
 from jpoke.core.battle import Battle
 from jpoke.core.player import Player
 from jpoke.enums.command import Command
-from jpoke.players.tree_search_player import total_hp_ratio
 
 # 実際の行動として選ばれることのない特殊コマンドは行動空間から除外する
 _EXCLUDED = (Command.STRUGGLE, Command.FORCED)
@@ -156,11 +156,13 @@ class RewardWeights:
 def calc_state_value(battle: Battle, player: Player, weights: RewardWeights) -> float:
     """現在の対戦状態の評価値を計算する（差分報酬の元になる値。poke-envのreward_computing_helperと同じ考え方）。
 
-    HP項は `TreeSearchPlayer.evaluate()` と同じ `total_hp_ratio()` を再利用する
-    （論点4: 「自チームの残りHP割合合計」を独自に再実装して評価基準が食い違うのを防ぐ）。
+    評価基準は利用者が `RewardWeights` で自由に変える前提の叩き台であり、
+    `players/tree_search_player.py` の評価ロジックとは独立させている（論点4）。
     """
     opponent = battle.opponent(player)
-    value = (total_hp_ratio(battle, player) - total_hp_ratio(battle, opponent)) * weights.hp
+    player_hp = sum(mon.hp_fraction for mon in battle.get_team(player) if not mon.fainted)
+    opponent_hp = sum(mon.hp_fraction for mon in battle.get_team(opponent) if not mon.fainted)
+    value = (player_hp - opponent_hp) * weights.hp
     for mon in battle.get_team(player):
         if mon.fainted:
             value -= weights.fainted
@@ -244,8 +246,8 @@ class RLBattleEnv:
 
 1. `src/jpoke/rl.py` を新規作成し、`ACTION_COMMANDS` / `command_to_action` /
    `action_to_command` / `get_action_mask` を実装する
-2. `RewardWeights` / `calc_state_value` を実装する（HP項は `players/tree_search_player.py` の
-   `total_hp_ratio()` を import して再利用し、独自に再実装しない。論点4参照）
+2. `RewardWeights` / `calc_state_value` を実装する（`players/tree_search_player.py` には
+   import 依存しない。`rl.py` 単体で完結させる。論点4参照）
 3. `embed_battle_basic` の最小参考実装を実装する（対象は要検討: 自分の場のポケモンの
    HP割合・状態異常有無・相手の場のポケモンの同項目、程度に留める）
 4. `RLBattleEnv` を実装する（論点1のA案で、まず「学習対象が瀕死交代を要求されない対戦

--- a/.internal/poke-env/rl_features_analysis.md
+++ b/.internal/poke-env/rl_features_analysis.md
@@ -111,11 +111,11 @@ poke_env/environment/
    （poke-envも同様に「利用者が実装する」設計だが、参考実装や助言用のヘルパーは一切ない）。
 3. **報酬シェーピングのヘルパー**（`reward_computing_helper` 相当）— HP割合・瀕死・状態異常・勝敗を
    使った差分報酬というAPIとしての形はjpokeにない。`tod_score(alpha)`（分類D）はダメージレース評価用の
-   スコアで、エピソード単位の報酬シェーピングとは目的が異なる。ただし構成要素の一部は既にある:
-   `total_hp_ratio(battle, target)`（`players/tree_search_player.py`）が「チームの残りHP割合合計」を
-   既に提供しており、`TreeSearchPlayer.evaluate()`（ミニマックス葉ノード評価、勝敗確定時は±inf）が
-   これを使っている。RL用の報酬ヘルパー（`rl_support.md` の `calc_state_value`）はこの関数を
-   再利用し、HP項の計算ロジックを二重実装しない設計にする（詳細は `rl_support.md` 論点4）。
+   スコアで、エピソード単位の報酬シェーピングとは目的が異なる。`players/tree_search_player.py` の
+   `total_hp_ratio(battle, target)`（`TreeSearchPlayer.evaluate()` が使うミニマックス葉ノード評価用の
+   HP割合合計）と、RL用の報酬ヘルパー（`rl_support.md` の `calc_state_value`）は評価対象こそ似るが、
+   評価関数は利用者が重み・実装ごと差し替える前提のものなので、`calc_state_value` 側は
+   `total_hp_ratio` を import せず独立に実装する（詳細は `rl_support.md` 論点4）。
 4. **行動マスク配列としての出力**（`Command`自体は固定順Enumで実質int変換済みだが、
    `get_available_commands(player)` の結果を `Discrete(N)` 用の0/1マスク配列に変換する層は未整備）。
 5. **`gymnasium`/`pettingzoo` への依存自体**（jpokeの実行時依存には一切なし。追加するかどうかも論点）。


### PR DESCRIPTION
## 概要
- `.internal/plan/poke-env/rl_support.md` の `calc_state_value()` が `players/tree_search_player.py` の `total_hp_ratio()` を import して再利用する設計だったが、ユーザー指摘の通り評価関数はどのみち利用者がカスタマイズする前提のものなので、厳密な再利用よりモジュール単体の独立性を優先する方針に修正
- HP項を自前でその場計算する形に戻し、論点4の理由付けを書き直した
- `.internal/poke-env/rl_features_analysis.md` の該当記述も整合を取った

## テスト
- ドキュメントのみの変更のためテスト実行なし