### PR TITLE
feat(utils): PokeAPI画像をダウンロードするAPIを追加

### DIFF
--- a/src/jpoke/__init__.py
+++ b/src/jpoke/__init__.py
@@ -7,7 +7,13 @@ from .core import Battle, Player
 from .enums import Command
 from .model import Pokemon, Ability, Item, Move
 from .data import POKEDEX, get_pokemon_by_regulation, get_items_by_regulation
-from .utils import get_pokeapi_url, get_pokemon_image_url, get_item_image_url
+from .utils import (
+    get_pokeapi_url,
+    get_pokemon_image_url,
+    get_item_image_url,
+    download_pokemon_image,
+    download_item_image,
+)
 
 # pyproject.toml の version と手動で一致させること（tests/test_version.py で検証）
 __version__ = "0.1.0"
@@ -26,4 +32,6 @@ __all__ = [
     "get_pokeapi_url",
     "get_pokemon_image_url",
     "get_item_image_url",
+    "download_pokemon_image",
+    "download_item_image",
 ]

--- a/src/jpoke/utils/__init__.py
+++ b/src/jpoke/utils/__init__.py
@@ -4,7 +4,13 @@
 """
 
 from .copy_utils import fast_copy, recursive_copy
-from .pokeapi import get_pokeapi_url, get_pokemon_image_url, get_item_image_url
+from .pokeapi import (
+    get_pokeapi_url,
+    get_pokemon_image_url,
+    get_item_image_url,
+    download_pokemon_image,
+    download_item_image,
+)
 
 __all__ = [
     "fast_copy",
@@ -12,4 +18,6 @@ __all__ = [
     "get_pokeapi_url",
     "get_pokemon_image_url",
     "get_item_image_url",
+    "download_pokemon_image",
+    "download_item_image",
 ]

--- a/src/jpoke/utils/pokeapi.py
+++ b/src/jpoke/utils/pokeapi.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from importlib import resources
+from pathlib import Path
 from typing import Literal, overload
+from urllib.request import Request, urlopen
 
 from jpoke.exceptions import PokeApiResolveError
 from jpoke.types import PokemonName, ItemName
@@ -92,6 +94,32 @@ def get_item_image_url(name_ja: ItemName) -> str:
     entity_id = _resolve_pokeapi_id(name_ja=name_ja, category="item")
     item_name = _resolve_item_pokeapi_name(entity_id)
     return f"{SPRITES_BASE}/items/{item_name}.png"
+
+
+def download_pokemon_image(
+    name_ja: PokemonName,
+    dest: str | Path,
+    image_type: PokemonImageType = "official-artwork",
+) -> Path:
+    """和名からポケモン画像をダウンロードし、指定パスに保存して返す。"""
+    url = get_pokemon_image_url(name_ja, image_type=image_type)
+    return _download_binary(url, Path(dest))
+
+
+def download_item_image(name_ja: ItemName, dest: str | Path) -> Path:
+    """和名からアイテム画像をダウンロードし、指定パスに保存して返す。"""
+    url = get_item_image_url(name_ja)
+    return _download_binary(url, Path(dest))
+
+
+def _download_binary(url: str, dest: Path) -> Path:
+    request = Request(url, headers={"User-Agent": "jpoke-pokeapi-image-downloader"})
+    with urlopen(request, timeout=20) as response:  # noqa: S310
+        data = response.read()
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    return dest
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_pokeapi.py
+++ b/tests/test_pokeapi.py
@@ -1,8 +1,16 @@
 """PokeAPI URL生成ユーティリティのテスト。"""
 
+from contextlib import contextmanager
+
 import pytest
 
-from jpoke import get_pokeapi_url, get_pokemon_image_url, get_item_image_url
+from jpoke import (
+    get_pokeapi_url,
+    get_pokemon_image_url,
+    get_item_image_url,
+    download_pokemon_image,
+    download_item_image,
+)
 from jpoke.exceptions import PokeApiResolveError
 
 
@@ -31,3 +39,47 @@ def test_get_item_image_url_アイテム画像URLを返す():
 def test_get_pokeapi_url_未解決名は例外を送出する():
     with pytest.raises(PokeApiResolveError):
         get_pokeapi_url("存在しない名前")
+
+
+def _fake_urlopen(requested_urls, body: bytes):
+    @contextmanager
+    def _open(request, timeout=20):
+        requested_urls.append(request.full_url)
+
+        class _Response:
+            def read(self_inner):
+                return body
+
+        yield _Response()
+
+    return _open
+
+
+def test_download_pokemon_image_画像を保存してパスを返す(monkeypatch, tmp_path):
+    requested_urls = []
+    monkeypatch.setattr(
+        "jpoke.utils.pokeapi.urlopen",
+        _fake_urlopen(requested_urls, b"pokemon-image-bytes"),
+    )
+
+    dest = tmp_path / "images" / "pikachu.png"
+    result = download_pokemon_image("ピカチュウ", dest)
+
+    assert result == dest
+    assert dest.read_bytes() == b"pokemon-image-bytes"
+    assert requested_urls == [get_pokemon_image_url("ピカチュウ")]
+
+
+def test_download_item_image_画像を保存してパスを返す(monkeypatch, tmp_path):
+    requested_urls = []
+    monkeypatch.setattr(
+        "jpoke.utils.pokeapi.urlopen",
+        _fake_urlopen(requested_urls, b"item-image-bytes"),
+    )
+
+    dest = tmp_path / "leftovers.png"
+    result = download_item_image("たべのこし", dest)
+
+    assert result == dest
+    assert dest.read_bytes() == b"item-image-bytes"
+    assert requested_urls == [get_item_image_url("たべのこし")]


### PR DESCRIPTION
## Summary
- `get_pokemon_image_url` / `get_item_image_url` はURLを返すだけだったため、実際に画像を取得して保存する `download_pokemon_image` / `download_item_image` を追加
- 内部は `_download_binary(url, dest)` 共通ヘルパーで `urllib.request.urlopen` によりバイト列を取得し、保存先ディレクトリを自動作成した上で書き込む（戻り値は保存先の `Path`）
- ライブラリ本体（`pyproject.toml` の `dependencies = []`）は無依存方針のため、`requests` 等は追加せず標準ライブラリの `urllib.request` のみを使用
- `jpoke.utils` / トップレベル `jpoke` から再エクスポート

## Test plan
- [x] `python -m pytest tests/test_pokeapi.py -v` — 7 passed（新規2件含む。`monkeypatch` で `urlopen` を差し替え、実ネットワークアクセスなしで保存パス・書き込み内容・リクエストURLを検証）
- [x] `python -m pytest tests/ -q` — 6136 passed, 1 skipped, 1 failed（failは今回の変更と無関係な既存の `test_examples_smoke.py` のCLIPlayer対話入力サンプルで、サブプロセスにstdinが無くEOFErrorになるもの。main側で既知）
- [x] `python -m ruff check` — 対象ファイルすべて通過