### PR TITLE
docs(examples): PokeAPI連携ユーティリティの使い方サンプルを追加

### DIFF
--- a/examples/04_others/pokeapi_utility.ipynb
+++ b/examples/04_others/pokeapi_utility.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1a2c3d4",
+   "metadata": {},
+   "source": [
+    "# PokeAPI連携ユーティリティ\n",
+    "\n",
+    "和名から [PokeAPI](https://pokeapi.co/) のURL・画像を取得する `jpoke.utils.pokeapi` の使い方を扱う。\n",
+    "\n",
+    "[▶ Google Colabで開く](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/pokeapi_utility.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2b3d4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q jpoke"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3c4e5f6",
+   "metadata": {},
+   "source": [
+    "`get_pokeapi_url()` で和名からPokeAPIのエンドポイントURLを取得できる。ポケモン・アイテムどちらも対応する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4d5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jpoke import get_pokeapi_url\n",
+    "\n",
+    "print(get_pokeapi_url(\"ピカチュウ\"))                   # ポケモン（category省略時は\"pokemon\"）\n",
+    "print(get_pokeapi_url(\"たべのこし\", category=\"item\"))  # アイテム"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5e6a7b8",
+   "metadata": {},
+   "source": [
+    "`get_pokemon_image_url()` / `get_item_image_url()` は画像（スプライト）のURLを返す。ポケモンは `image_type` で公式アートワーク・ドット絵・色違いなど種類を指定できる。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6f7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jpoke import get_pokemon_image_url, get_item_image_url\n",
+    "\n",
+    "print(get_pokemon_image_url(\"ピカチュウ\"))  # 既定は公式アートワーク\n",
+    "print(get_pokemon_image_url(\"ピカチュウ\", image_type=\"showdown-front-shiny\"))\n",
+    "print(get_item_image_url(\"たべのこし\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7a8c9d0",
+   "metadata": {},
+   "source": [
+    "URLではなく画像ファイル自体が欲しい場合は `download_pokemon_image()` / `download_item_image()` を使う。指定したパスへ画像をダウンロードして保存し、保存先の `Path` を返す（保存先ディレクトリが存在しなければ自動作成される）。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8b9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from jpoke import download_pokemon_image, download_item_image\n",
+    "\n",
+    "dest_dir = Path(tempfile.gettempdir()) / \"jpoke_images\"\n",
+    "pikachu_path = download_pokemon_image(\"ピカチュウ\", dest_dir / \"pikachu.png\")\n",
+    "leftovers_path = download_item_image(\"たべのこし\", dest_dir / \"leftovers.png\")\n",
+    "\n",
+    "print(f\"{pikachu_path} ({pikachu_path.stat().st_size} bytes)\")\n",
+    "print(f\"{leftovers_path} ({leftovers_path.stat().st_size} bytes)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9c0e1f2",
+   "metadata": {},
+   "source": [
+    "和名がPokeAPI側に見つからない場合、上記いずれの関数も `PokeApiResolveError` を送出する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0d1f2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jpoke.exceptions import PokeApiResolveError\n",
+    "\n",
+    "try:\n",
+    "    get_pokeapi_url(\"存在しないポケモン\")\n",
+    "except PokeApiResolveError as e:\n",
+    "    print(f\"解決できませんでした: {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,7 @@ AI開発（`MinimaxPlayer` を継承した木探索AIのカスタマイズ）
 | [`logcode.ipynb`](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/logcode.ipynb) | `LogCode` の種類の確認方法（`battle.get_event_logs(turn)` によるログ種別の抽出） |
 | [`poke_env_style_player.ipynb`](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/poke_env_style_player.ipynb) | poke-env互換プロパティ（`battle.available_moves` 等）を使った `choose_command()` の実装 |
 | [`pokedex.ipynb`](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/pokedex.ipynb) | `Pokemon.data` を通した図鑑データ（持てる特性・覚えられる技など）の取得 |
+| [`pokeapi_utility.ipynb`](https://colab.research.google.com/github/tmwork1/jpoke/blob/main/examples/04_others/pokeapi_utility.ipynb) | `jpoke.utils.pokeapi` によるPokeAPIのURL取得（`get_pokeapi_url`等）・画像ダウンロード（`download_pokemon_image`等） |
 
 ## 05_advanced/
 


### PR DESCRIPTION
## Summary
- `jpoke.utils.pokeapi` の使い方を扱うノートブック `examples/04_others/pokeapi_utility.ipynb` を追加
  - `get_pokeapi_url()` — 和名からPokeAPIエンドポイントURLを取得（ポケモン・アイテム）
  - `get_pokemon_image_url()` / `get_item_image_url()` — 画像（スプライト）URLの取得
  - `download_pokemon_image()` / `download_item_image()` — 実際に画像をダウンロードして保存（一時ディレクトリへ保存する例で、リポジトリを汚さない書き方にした）
  - 未解決名での `PokeApiResolveError` 送出
- `examples/README.md` の `04_others/` 一覧に追加

## Test plan
- [x] papermillでノートブックを実際に実行し、全セルがエラーなく完走することを確認（実際にPokeAPI・GitHub sprites へのネットワークアクセスを行う）
- [x] `pytest tests/test_examples_smoke.py::test_notebook_examples_...[04_others/pokeapi_utility.ipynb]` — PASSED
- [x] `python -m pytest tests/ -q` — 6137 passed, 1 skipped, 1 failed（failは今回の変更と無関係な既存の `test_examples_smoke.py` のCLIPlayer対話入力サンプルで、サブプロセスにstdinが無くEOFErrorになるもの。main側で既知）