### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-22
+
 ### Added
 
 - `jpoke.players.MinimaxPlayer` — 自分の各合法手について、相手が最善（自分に

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jpoke"
-version = "0.1.0"
+version = "0.2.0"
 description = "Event-driven Pokemon Champions single-battle simulation and damage calculation library (unofficial)"
 authors = [
     { name = "Tomoo Mari", email = "tmtm.holmes@gmail.com" }

--- a/src/jpoke/__init__.py
+++ b/src/jpoke/__init__.py
@@ -16,7 +16,7 @@ from .utils import (
 )
 
 # pyproject.toml の version と手動で一致させること（tests/test_version.py で検証）
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "Battle",


### PR DESCRIPTION
## Summary
- CHANGELOG.md の `[Unreleased]` を `[0.2.0] - 2026-07-22` としてリリース
- `pyproject.toml` / `src/jpoke/__init__.py` の version を 0.2.0 に更新

## Test plan
- [x] `python -m pytest tests/ -q` — 6166 passed, 1 skipped, 1 failed（失敗は
  `tests/test_examples_smoke.py` の `05_cli_vs_ai.py` 実行テストで、本PRの変更とは
  無関係の既存不具合。別issueで対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)