### PR TITLE
fix(tests): 対話型サンプルをスモークテスト対象から除外

### DIFF
--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -27,8 +27,15 @@ PYTHON = resolve_subprocess_python("papermill", "jpoke")
 NOTEBOOK_EXAMPLES = sorted(
     p.relative_to(EXAMPLES_DIR).as_posix() for p in EXAMPLES_DIR.glob("**/*.ipynb")
 )
+# 標準入力からの対話操作を前提とするサンプルはCI上のsubprocessではEOFErrorになるため、
+# エラーなく終了することの確認（スモークテスト）の対象から除外する。
+INTERACTIVE_PY_EXAMPLES = {
+    "01_getting_started/05_cli_vs_ai.py",
+}
 PY_EXAMPLES = sorted(
-    p.relative_to(EXAMPLES_DIR).as_posix() for p in EXAMPLES_DIR.glob("**/*.py")
+    p.relative_to(EXAMPLES_DIR).as_posix()
+    for p in EXAMPLES_DIR.glob("**/*.py")
+    if p.relative_to(EXAMPLES_DIR).as_posix() not in INTERACTIVE_PY_EXAMPLES
 )
 
 # スモークテストの目的は「エラーなく終了すること」の確認のみであり、README掲載用の


### PR DESCRIPTION
## Summary
- `examples/01_getting_started/05_cli_vs_ai.py` は `CLIPlayer` による標準入力前提の対話型サンプルで、CI上の subprocess には stdin が繋がっていないため常に `EOFError` で失敗していた（main で長期間連続してCI失敗）
- `tests/test_examples_smoke.py` の `PY_EXAMPLES` から対話型サンプルを除外するリスト（`INTERACTIVE_PY_EXAMPLES`）を追加

## Test plan
- [x] `python -m pytest tests/test_examples_smoke.py -v -k "py_examples"` が通過
- [x] `python -m pytest tests/ -q` 全件通過（6171 passed, 1 skipped）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>