### PR TITLE
fix: package-dataのglobパターン漏れでpokeapi用JSONがwheelから欠落する問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,8 @@ jobs:
       - name: Import from outside the repo
         # cwd の src/ を拾わないよう /tmp で実行し、wheel からのみ import できることを確認する
         run: cd /tmp && python -c "import jpoke; print(jpoke.__version__)"
+
+      - name: Verify all data files are packaged
+        # src/jpoke/data 配下のデータファイルが package-data のパターン漏れで
+        # wheel から欠落していないかを検証する
+        run: python scripts/check_package_data.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 jpoke = ["py.typed"]
-"jpoke.data" = ["*.json", "ps-champ-ja/*.json", "regulation/*.csv"]
+"jpoke.data" = ["**/*.json", "**/*.csv"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/check_package_data.py
+++ b/scripts/check_package_data.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""src/jpoke/data 配下のデータファイルがビルド済みwheelに漏れなく同梱されているか検証するスクリプト。
+
+想定される使い方（CI）:
+    python -m build -w .
+    pip install dist/*.whl
+    python scripts/check_package_data.py
+
+`pip install` した環境に対して実行する（importする jpoke はインストール済みのものを指す）。
+pyproject.toml の [tool.setuptools.package-data] のパターン漏れで、実行時に
+importlib.resources 経由で読むデータファイルが同梱されない事故を検出する。
+"""
+import sys
+from pathlib import Path
+
+_EXCLUDE_SUFFIXES = {".py", ".pyc"}
+_EXCLUDE_DIR_NAMES = {"__pycache__"}
+
+
+def _collect_data_files(root: Path) -> set[str]:
+    files = set()
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        if path.suffix in _EXCLUDE_SUFFIXES:
+            continue
+        if _EXCLUDE_DIR_NAMES & set(path.relative_to(root).parts):
+            continue
+        files.add(path.relative_to(root).as_posix())
+    return files
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    source_dir = repo_root / "src" / "jpoke" / "data"
+
+    import jpoke  # インストール済み（wheel由来）のパッケージを解決する
+
+    installed_dir = Path(jpoke.__file__).resolve().parent / "data"
+
+    source_files = _collect_data_files(source_dir)
+    installed_files = _collect_data_files(installed_dir)
+
+    missing = sorted(source_files - installed_files)
+    if missing:
+        print("以下のデータファイルがビルド済みパッケージに同梱されていません:")
+        for f in missing:
+            print(f"  - {f}")
+        print("pyproject.toml の [tool.setuptools.package-data] を確認してください。")
+        return 1
+
+    print(f"OK: {len(source_files)} 件のデータファイルすべてが同梱されています。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `pyproject.toml` の `jpoke.data` package-data を個別列挙から再帰glob（`**/*.json`, `**/*.csv`）に変更し、`src/jpoke/data/pokeapi/*.json` がwheelに同梱されない問題を修正
- 公開API `jpoke.get_pokeapi_url()` は実行時にこれらのJSONを読むため、pip installのみの環境で`FileNotFoundError`になっていた（README「スタンドアロン」謳い文句に反する挙動）
- `scripts/check_package_data.py` を追加し、ソース上のデータファイル一覧とビルド済みwheelの同梱ファイル一覧をdiffする汎用チェックをCIの`package-check`ジョブに組み込み。今後同種のパターン漏れが発生しても自動検出される

## Test plan
- [x] 新パターンでwheelをビルドし、クリーンなvenvにpip installして`get_pokeapi_url()`が正常に動作することを確認
- [x] `scripts/check_package_data.py`が13件のデータファイル全同梱を確認
- [x] 旧パターン（列挙漏れあり）で意図的にビルドし、チェックスクリプトが欠落を正しく検出してexit 1することを確認
- [x] `ruff check scripts/check_package_data.py` 通過
- [ ] CI（GitHub Actions）でのpackage-checkジョブ実行結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)