### PR TITLE
docs(progress): ailment.mdにゆめうつつの実装完了行を追加

### DIFF
--- a/.internal/progress/ailment.md
+++ b/.internal/progress/ailment.md
@@ -5,3 +5,4 @@
 やけど	x	x	x	x	x	x	x
 ねむり	x	x	x	x	n/a	n/a	x
 こおり	x	x	x	x	n/a	n/a	x
+ゆめうつつ	x	x	x	x	n/a	n/a	x


### PR DESCRIPTION
## Summary
- `ゆめうつつ`（へんしん + ぜったいねむりコピー時の状態）は実装・テスト・バグ修正（723469caa）済みだが、`.internal/progress/ailment.md` への追記が漏れていた
- 進捗表に実装完了として1行追加

## Test plan
- ドキュメントのみの変更のためテスト実行なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)